### PR TITLE
Implement searchWithScores method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export type {
     CollectionSearchEngine,
     CollectionSearchEngineFactory,
     CollectionSearchMatch,
+    CollectionSearchResult,
     CollectionSearchOptions,
 } from "./search/types";
 export type {

--- a/src/search/catalog.test.ts
+++ b/src/search/catalog.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { Collection } from '../types';
 import { InMemoryCollectionCatalog } from './catalog';
-import type { CollectionSearchEngine } from './types';
+import type { CollectionSearchEngine, CollectionSearchMatch } from './types';
 
 const FIXTURES: Collection[] = [
   {
@@ -31,14 +31,19 @@ const FIXTURES: Collection[] = [
 ];
 
 class StubSearchEngine implements CollectionSearchEngine {
-  private readonly idsByQuery: Record<string, string[]>;
+  private readonly matchesByQuery: Record<string, CollectionSearchMatch[]>;
 
-  constructor(idsByQuery: Record<string, string[]>) {
-    this.idsByQuery = idsByQuery;
+  constructor(matchesByQuery: Record<string, Array<string | CollectionSearchMatch>>) {
+    this.matchesByQuery = Object.fromEntries(
+      Object.entries(matchesByQuery).map(([query, matches]) => [
+        query,
+        matches.map((match) => (typeof match === 'string' ? { id: match } : match)),
+      ]),
+    );
   }
 
   search(query: string) {
-    return (this.idsByQuery[query] || []).map((id) => ({ id }));
+    return this.matchesByQuery[query] || [];
   }
 }
 
@@ -61,6 +66,65 @@ describe('InMemoryCollectionCatalog', () => {
 
     const ids = catalog.search('many', { limit: 2 }).map((collection) => collection.id);
     expect(ids).toEqual(['NS:third', 'NS:second']);
+  });
+
+  it('returns plain collections from search for compatibility', () => {
+    const engine = new StubSearchEngine({
+      scored: [{ id: 'NS:first', score: 4.2 }],
+    });
+    const catalog = new InMemoryCollectionCatalog(FIXTURES, { engine });
+
+    expect(catalog.search('scored')).toEqual([FIXTURES[0]]);
+  });
+
+  it('propagates score while preserving order and ignoring unknown ids', () => {
+    const engine = new StubSearchEngine({
+      ordered: [
+        { id: 'NS:third', score: 3.5 },
+        { id: 'NS:unknown', score: 3.4 },
+        { id: 'NS:first', score: 1.2 },
+      ],
+    });
+    const catalog = new InMemoryCollectionCatalog(FIXTURES, { engine });
+
+    expect(catalog.searchWithScores('ordered')).toEqual([
+      { collection: FIXTURES[2], score: 3.5 },
+      { collection: FIXTURES[0], score: 1.2 },
+    ]);
+  });
+
+  it('applies limit to scored results', () => {
+    const engine = new StubSearchEngine({
+      many: [
+        { id: 'NS:third', score: 3 },
+        { id: 'NS:second', score: 2 },
+        { id: 'NS:first', score: 1 },
+      ],
+    });
+    const catalog = new InMemoryCollectionCatalog(FIXTURES, { engine });
+
+    expect(catalog.searchWithScores('many', { limit: 2 })).toEqual([
+      { collection: FIXTURES[2], score: 3 },
+      { collection: FIXTURES[1], score: 2 },
+    ]);
+  });
+
+  it('returns cloned collections from scored search results', () => {
+    const engine = new StubSearchEngine({
+      scored: [{ id: 'NS:first', score: 4.2 }],
+    });
+    const catalog = new InMemoryCollectionCatalog(FIXTURES, { engine });
+
+    const [result] = catalog.searchWithScores('scored');
+    result.collection.title = 'Mutated title';
+    result.collection.properties[0].type = 'number';
+
+    expect(catalog.searchWithScores('scored')).toEqual([
+      {
+        collection: FIXTURES[0],
+        score: 4.2,
+      },
+    ]);
   });
 
   it('returns cloned values from list and getById', () => {

--- a/src/search/catalog.ts
+++ b/src/search/catalog.ts
@@ -2,13 +2,16 @@ import type { Collection } from '../types';
 import type {
   CollectionSearchEngine,
   CollectionSearchEngineFactory,
+  CollectionSearchMatch,
   CollectionSearchOptions,
+  CollectionSearchResult,
 } from './types';
 
 export interface CollectionCatalog {
   list(): Collection[];
   getById(id: string): Collection | undefined;
   search(query: string, options?: CollectionSearchOptions): Collection[];
+  searchWithScores(query: string, options?: CollectionSearchOptions): CollectionSearchResult[];
 }
 
 export type InMemoryCollectionCatalogOptions =
@@ -45,28 +48,45 @@ export class InMemoryCollectionCatalog implements CollectionCatalog {
     return collection ? structuredClone(collection) : undefined;
   }
 
-  search(query: string, options: CollectionSearchOptions = {}): Collection[] {
+  private getSearchEngine(): CollectionSearchEngine {
     if (!this.searchEngine) {
       throw new Error('No search engine configured');
     }
+    return this.searchEngine;
+  }
 
-    const matches = this.searchEngine.search(query);
+  private resolveMatches(
+    matches: CollectionSearchMatch[],
+    options: CollectionSearchOptions = {},
+  ): CollectionSearchResult[] {
+    const limit = options.limit;
+    const hasLimit = typeof limit === 'number' && limit >= 0;
+    const resolvedResults: CollectionSearchResult[] = [];
 
-    const matchedCollections: Collection[] = [];
-    
     // Keep the search-engine ranking order while resolving IDs to collections.
+    // Stop early once the limit is reached to avoid cloning unused items.
     for (const match of matches) {
+      if (hasLimit && resolvedResults.length >= limit) {
+        break;
+      }
       const collection = this.byId.get(match.id);
       if (collection !== undefined) {
-        matchedCollections.push(collection);
+        resolvedResults.push({
+          collection: structuredClone(collection),
+          score: match.score,
+        });
       }
     }
 
-    const limit = options.limit;
-    if (typeof limit === 'number' && limit >= 0) {
-      return structuredClone(matchedCollections.slice(0, limit));
-    }
+    return resolvedResults;
+  }
 
-    return structuredClone(matchedCollections);
+  search(query: string, options: CollectionSearchOptions = {}): Collection[] {
+    return this.searchWithScores(query, options).map(({ collection }) => collection);
+  }
+
+  searchWithScores(query: string, options: CollectionSearchOptions = {}): CollectionSearchResult[] {
+    const matches = this.getSearchEngine().search(query);
+    return this.resolveMatches(matches, options);
   }
 }

--- a/src/search/types.ts
+++ b/src/search/types.ts
@@ -11,6 +11,12 @@ export type CollectionSearchMatch = {
   score?: number;
 };
 
+/** A catalog search result that includes the resolved collection and optional relevance score. */
+export type CollectionSearchResult = {
+  collection: Collection;
+  score?: number;
+};
+
 /** Contract that any search engine implementation must satisfy. */
 export interface CollectionSearchEngine {
   search(query: string): CollectionSearchMatch[];


### PR DESCRIPTION
closes #23 

## Summary

This PR adds scored search results to the collection catalog without changing the existing `search()` contract.

## Changes

- add `searchWithScores()` to `CollectionCatalog`
- introduce `CollectionSearchResult` with `collection` and optional `score`
- keep `search()` backward-compatible by still returning plain `Collection[]`
- preserve search-engine ranking order, ignore unknown IDs, and apply `limit` consistently
- keep returned search results cloned before exposure
- export `CollectionSearchResult` from the package entrypoint
- add test coverage for scored results, ordering, limiting, compatibility, and cloning

## Validation

- `npm run typecheck`
- `npm test`
- `npm run build`