### PR TITLE
Declare and validate CollectionPropertyType

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -24,5 +24,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
+    - run: npm run typecheck
     - run: npm run build --if-present
     - run: npm test

--- a/src/helpers/compare.test.ts
+++ b/src/helpers/compare.test.ts
@@ -24,8 +24,8 @@ describe('compare', () => {
     const overwrite: Collection = {
       ...base,
       properties: [
-        { name: 'id', type: 'number' },
-        { name: 'name', type: 'text' },
+        { name: 'id', type: 'integer' },
+        { name: 'name', type: 'boolean' },
       ],
     }
 

--- a/src/helpers/compare.ts
+++ b/src/helpers/compare.ts
@@ -1,4 +1,4 @@
-import type { Collection } from "../types";
+import type { Collection, CollectionOverwrite } from "../types";
 
 /**
  * Compare properties between original and overwrite to ensure that both are synchronized.
@@ -7,7 +7,7 @@ import type { Collection } from "../types";
  * @param overwrite The collection from data/overwrite
  * @returns 
  */
-export function compare(original: Collection, overwrite?: Collection|null): string[] {
+export function compare(original: Collection, overwrite?: CollectionOverwrite|null): string[] {
     if (!overwrite) {
         return [];
     }
@@ -23,5 +23,4 @@ export function compare(original: Collection, overwrite?: Collection|null): stri
 
     return differences;
 }
-
 

--- a/src/helpers/merge.test.ts
+++ b/src/helpers/merge.test.ts
@@ -60,6 +60,20 @@ describe('mergeCollectionSchema', () => {
     })
   })
 
+  it('allows legacy overwrite types but keeps the original WFS type', () => {
+    const overwrite = {
+      ...base,
+      properties: [
+        { name: 'nature', type: 'numeric', title: 'Nature' },
+      ],
+    }
+
+    expect(merge(base, overwrite).properties).toEqual([
+      { name: 'geom', type: 'geometry' },
+      { name: 'nature', type: 'string', title: 'Nature' },
+    ])
+  })
+
   it('should keep id from original', () => {
     const overwrite: Collection = {
       ...base,

--- a/src/helpers/merge.test.ts
+++ b/src/helpers/merge.test.ts
@@ -8,18 +8,25 @@ const base: Collection = {
   name: 'collection',
   title: 'Base title',
   description: 'Base description',
-  properties: [{ name: 'geom', type: 'geometry' }],
+  properties: [
+    { name: 'geom', type: 'geometry' },
+    { name: 'nature', type: 'string' },
+  ],
 }
 
 describe('mergeCollectionSchema', () => {
-  it('keeps collection id, namespace and name and and original property names; other fields from overwrite', () => {
+
+  it('keeps collection id, namespace, name and original property names/types; other property fields from overwrite', () => {
     const overwrite: Collection = {
       id: 'NS:collection',
       namespace: 'NS',
       name: 'collection',
       title: 'Other title',
       description: 'Other description',
-      properties: [{ name: 'id', type: 'string' }],
+      properties: [
+        { name: 'geom', type: 'geometry', title: 'Overwritten title' },
+        { name: 'nature', type: 'integer', description: 'Modified nature' },
+      ],
     }
 
     expect(merge(base, overwrite)).toEqual({
@@ -28,16 +35,29 @@ describe('mergeCollectionSchema', () => {
       name: 'collection',
       title: 'Other title',
       description: 'Other description',
-      properties: [{ name: 'geom', type: 'geometry' }],
+      properties: [
+        { name: 'geom', type: 'geometry', title: 'Overwritten title' },
+        { name: 'nature', type: 'string', description: 'Modified nature' },
+      ],
     })
   })
 
-  it('should ignore and report extra properties in overwrite', () => {
+  it('should ignore extra properties in overwrite (only merge matching properties)', () => {
     const overwrite: Collection = {
       ...base,
-      properties: [{ name: 'id', type: 'string' }, { name: 'extra', type: 'string' }],
+      properties: [
+        { name: 'geom', type: 'string', title: 'Modified' },
+        { name: 'nature', type: 'integer', description: 'Modified nature' },
+        { name: 'extra', type: 'string' },
+      ],
     }
-    expect(merge(base, overwrite)).toEqual(base)
+    expect(merge(base, overwrite)).toEqual({
+      ...base,
+      properties: [
+        { name: 'geom', type: 'geometry', title: 'Modified' },
+        { name: 'nature', type: 'string', description: 'Modified nature' },
+      ],
+    })
   })
 
   it('should keep id from original', () => {
@@ -69,7 +89,7 @@ describe('mergeCollectionSchema', () => {
       ...base,
       title: 'Modified title',
     }
-    expect(merge(base, overwrite)).toEqual(overwrite)
+    expect(merge(base, overwrite).title).toEqual(overwrite.title)
   })
 
 
@@ -78,14 +98,14 @@ describe('mergeCollectionSchema', () => {
       ...base,
       description: 'Modified description',
     }
-    expect(merge(base, overwrite)).toEqual(overwrite)
+    expect(merge(base, overwrite).description).toEqual(overwrite.description)
   })
 
   it('should use description from original if overwrite is not provided', () => {
     const overwrite: Collection = {
       ...base
     }
-    expect(merge(base, overwrite)).toEqual(base)
+    expect(merge(base, overwrite).description).toEqual(base.description)
   })
 
   it('keeps geometry properties from original when they define defaultCrs', () => {

--- a/src/helpers/merge.ts
+++ b/src/helpers/merge.ts
@@ -19,7 +19,7 @@ import type { Collection } from "../types";
  * - properties are iterated from original (order kept)
  * - properties with `defaultCrs` are kept from original as-is
  * - matching is done by property name
- * - if a property exists in overwrite, its fields are taken but name is kept from original
+ * - if a property exists in overwrite, its fields are taken but name and type are kept from original
  * - if a property does not exist in overwrite, the original property is kept
  * - new properties from overwrite are ignored
  *
@@ -48,6 +48,7 @@ export function merge(
         return {
             ...overProp,
             name: origProp.name,
+            type: origProp.type,
         }
     })
 

--- a/src/helpers/merge.ts
+++ b/src/helpers/merge.ts
@@ -1,7 +1,7 @@
 import {debuglog} from 'node:util';
 const debug = debuglog('gpf-schema-store:merge');
 
-import type { Collection } from "../types";
+import type { Collection, CollectionOverwrite } from "../types";
 
 /**
  * Merge two collection schemas with the following rules :
@@ -29,7 +29,7 @@ import type { Collection } from "../types";
  */
 export function merge(
     original: Collection,
-    overwrite: Collection | null
+    overwrite: CollectionOverwrite | null
 ): Collection {
     if ( ! overwrite ){
         debug(`No overwrite found for collection "${original.id}", using original schema`);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -54,7 +54,7 @@ describe('getCollections (library API)', () => {
 
     const first = getCollections()
     first[0].title = 'mutated by caller'
-    first[0].properties[0].type = 'number'
+    first[0].properties[0].type = 'float'
 
     const second = getCollections()
     expect(second[0].title).toBe('stable')

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { loadCollections } from "./services/storage";
 import { InMemoryCollectionCatalog } from "./search/catalog";
 import { MiniSearchCollectionSearchEngine } from "./search/minisearch-engine";
 
-export type { Collection, CollectionProperty } from "./types";
+export type { Collection, CollectionProperty, CollectionPropertyType } from "./types";
 export type {
     CollectionCatalog,
     InMemoryCollectionCatalogOptions as CollectionCatalogOptions,

--- a/src/search/catalog.test.ts
+++ b/src/search/catalog.test.ts
@@ -117,7 +117,7 @@ describe('InMemoryCollectionCatalog', () => {
 
     const [result] = catalog.searchWithScores('scored');
     result.collection.title = 'Mutated title';
-    result.collection.properties[0].type = 'number';
+    result.collection.properties[0].type = 'float';
 
     expect(catalog.searchWithScores('scored')).toEqual([
       {
@@ -132,7 +132,7 @@ describe('InMemoryCollectionCatalog', () => {
 
     const listed = catalog.list();
     listed[0].title = 'Mutated title';
-    listed[0].properties[0].type = 'number';
+    listed[0].properties[0].type = 'float';
 
     const listedAgain = catalog.list();
     expect(listedAgain[0].title).toBe('First');

--- a/src/search/minisearch-engine.test.ts
+++ b/src/search/minisearch-engine.test.ts
@@ -154,7 +154,7 @@ describe('MiniSearchCollectionSearchEngine identifier token indexing', () => {
       name: 'batiment',
       title: 'Batiment',
       description: 'Batiment',
-      properties: [{ name: 'hauteur', type: 'number' }],
+      properties: [{ name: 'hauteur', type: 'float' }],
     },
     {
       id: 'ADMINEXPRESS-COG.LATEST:commune',

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -1,5 +1,5 @@
 import { dirname, join } from "path";
-import type { Collection, NamespaceFilterRule } from "../types";
+import type { Collection, CollectionOverwrite, NamespaceFilterRule } from "../types";
 import { fileURLToPath } from "url";
 import {
     existsSync,
@@ -154,10 +154,10 @@ export function clearWfsCollections(): void {
  * @param name - The name of the collection
  * @returns The overwrite for the collection if it exists, null otherwise
  */
-export function getOverwrite(namespace: string, name: string): Collection | null {
+export function getOverwrite(namespace: string, name: string): CollectionOverwrite | null {
     const overwritePath = join(DATA_DIR, 'overwrites', namespace, `${name}.json`);
     if (existsSync(overwritePath)) {
-        return JSON.parse(readFileSync(overwritePath, 'utf-8')) as Collection;
+        return JSON.parse(readFileSync(overwritePath, 'utf-8')) as CollectionOverwrite;
     }
     return null;
 }

--- a/src/services/wfs.test.ts
+++ b/src/services/wfs.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { UnexpectedTypeError } from '../types'
 
 /**
  * Mocks for WfsEndpoint methods used by the unit tests.
@@ -106,10 +107,10 @@ describe('WfsClient', () => {
       endpointMocks.getFeatureTypeFull.mockResolvedValue({
         properties: {
           prop1: 'string',
-          prop2: 'number',
+          prop2: 'float',
         },
         geometryName: 'geom',
-        geometryType: 'Polygon',
+        geometryType: 'polygon',
         defaultCrs: 'EPSG:4326',
         title: 'collection title',
         abstract: 'collection description',
@@ -127,8 +128,8 @@ describe('WfsClient', () => {
         description: 'collection description',
         properties: [
           { name: 'prop1', type: 'string' },
-          { name: 'prop2', type: 'number' },
-          { name: 'geom', type: 'Polygon', defaultCrs: 'EPSG:4326' },
+          { name: 'prop2', type: 'float' },
+          { name: 'geom', type: 'polygon', defaultCrs: 'EPSG:4326' },
         ],
       })
       await vi.runAllTimersAsync()
@@ -182,7 +183,7 @@ describe('WfsClient', () => {
       endpointMocks.getFeatureTypeFull.mockResolvedValue({
         properties: {
           prop1: 'string',
-          prop2: 'number',
+          prop2: 'float',
         },
         geometryName: 'geom',
         geometryType: 'unknown',
@@ -203,7 +204,7 @@ describe('WfsClient', () => {
         description: 'collection description',
         properties: [
           { name: 'prop1', type: 'string' },
-          { name: 'prop2', type: 'number' },
+          { name: 'prop2', type: 'float' },
           { name: 'geom', type: 'geometry', defaultCrs: 'EPSG:4326' },
         ],
       })
@@ -212,6 +213,31 @@ describe('WfsClient', () => {
       await assertion
     });
 
+  })
+
+  describe('WfsClient getCollection with unexpected property type', () => {
+    beforeEach(() => {
+      endpointMocks.getFeatureTypeFull.mockResolvedValue({
+        properties: {
+          prop1: 'string',
+          prop2: 'binary',
+        },
+        geometryName: 'geom',
+        geometryType: 'polygon',
+        defaultCrs: 'EPSG:4326',
+        title: 'collection title',
+        abstract: 'collection description',
+      })
+    })
+
+    it('throws UnexpectedTypeError when property type is invalid', async () => {
+      const wfsClient = new WfsClient('https://example.test/wfs')
+      const promise = wfsClient.getCollection('NS:collection')
+      const assertion = expect(promise).rejects.toThrow(UnexpectedTypeError)
+      await vi.runAllTimersAsync()
+
+      await assertion
+    })
   })
 
 })

--- a/src/services/wfs.ts
+++ b/src/services/wfs.ts
@@ -2,6 +2,7 @@ import { debuglog } from 'node:util';
 const debug = debuglog('gpf-schema-store:wfs');
 
 import type { Collection, CollectionBrief, CollectionProperty } from '../types';
+import { assertIsValidPropertyType } from '../types';
 import { WfsEndpoint } from '@camptocamp/ogc-client';
 import '../helpers/configure-fetch';
 import { retry } from '../helpers/retry';
@@ -141,17 +142,19 @@ export class WfsClient {
     );
 
     const properties = Object.getOwnPropertyNames(featureTypeFull.properties).map((propertyName) => {
+      const propertyType = featureTypeFull.properties[propertyName];
       return {
         name: propertyName,
-        type: featureTypeFull.properties[propertyName]
+        type: assertIsValidPropertyType(propertyType, `for property "${propertyName}" in collection "${collectionId}"`)
       } as CollectionProperty;
     });
 
     if (featureTypeFull.geometryName) {
       const geometryType = featureTypeFull.geometryType ?? 'geometry';
+      const normalizedType = geometryType !== 'unknown' ? geometryType : 'geometry';
       properties.push({
         name: featureTypeFull.geometryName,
-        type: geometryType !== 'unknown' ? geometryType : 'geometry',
+        type: assertIsValidPropertyType(normalizedType, `for geometry property "${featureTypeFull.geometryName}" in collection "${collectionId}"`),
         defaultCrs: featureTypeFull.defaultCrs
       } as CollectionProperty);
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -181,6 +181,30 @@ export type Collection = {
 };
 
 /**
+ * A property from an overwrite file.
+ *
+ * Overwrite files may still contain legacy or richer type names. They are
+ * enrichment inputs only: the merged collection keeps the WFS property type.
+ */
+export type CollectionPropertyOverwrite = Omit<CollectionProperty, 'type'> & {
+  /**
+   * Legacy field ignored by merge. Kept permissive because existing overwrite
+   * JSON files can contain values such as "numeric".
+   */
+  type?: string;
+};
+
+/**
+ * The schema of a collection overwrite.
+ */
+export type CollectionOverwrite = Omit<Collection, 'properties'> & {
+  /**
+   * The properties of the overwrite.
+   */
+  properties: CollectionPropertyOverwrite[];
+};
+
+/**
  * A brief version of the collection provided by GetCapabilities
  * without the properties (given by DescribeFeatureType)
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,11 +61,11 @@ export const namespaceFiltersSchema = z.object({
 
 /**
  * This is the current list of the core types for the properties of a collection.
- * 
+ *
  * Note that :
  * - The current reference is the list of types provided by ogc-client for WFS properties, which includes both scalar types and geometry types.
  * - It will likely need to be extended in the future to include more specific types (ex : date, datetime, etc.)
- * 
+ *
  * @see https://github.com/ignfab/gpf-schema-store/issues/25
  */
 const PROPERTY_TYPES = [
@@ -79,7 +79,7 @@ const PROPERTY_TYPES = [
   'multilinestring',
   'multipolygon',
   'multipoint',
-  'geometry', // not in ogc-client (to avoid unknown type for geometry) 
+  'geometry', // not in ogc-client (to avoid unknown type for geometry)
 ] as const;
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,23 @@
 import { z } from 'zod';
 
 /**
+ * Error thrown when an unexpected or invalid property type is encountered.
+ */
+export class UnexpectedTypeError extends Error {
+  /**
+   * @param value the unexpected value
+   * @param context optional context about where the error occurred
+   */
+  constructor(value: unknown, context?: string) {
+    const message = context
+      ? `Unexpected type: "${value}" ${context}`
+      : `Unexpected type: "${value}"`;
+    super(message);
+    this.name = 'UnexpectedTypeError';
+  }
+}
+
+/**
  * The schema of the metadata of a namespace, currently assigned in data/namespace-filters.yaml
  * 
  * Note that no additional properties are allowed in the metadata object (strict).
@@ -34,7 +51,6 @@ export const namespaceFilterRuleSchema = z.object({
  */
 export type NamespaceFilterRule = z.infer<typeof namespaceFilterRuleSchema>;
 
-
 /**
  * The schema of the data/namespace-filters.yaml file, which contains rules
  * to assign metadata to namespaces based on pattern matching.
@@ -43,6 +59,62 @@ export const namespaceFiltersSchema = z.object({
     rules: z.array(namespaceFilterRuleSchema),
 });
 
+/**
+ * This is the current list of the core types for the properties of a collection.
+ * 
+ * Note that :
+ * - The current reference is the list of types provided by ogc-client for WFS properties, which includes both scalar types and geometry types.
+ * - It will likely need to be extended in the future to include more specific types (ex : date, datetime, etc.)
+ * 
+ * @see https://github.com/ignfab/gpf-schema-store/issues/25
+ */
+const PROPERTY_TYPES = [
+  'string',
+  'boolean',
+  'float',
+  'integer',
+  'point',
+  'linestring',
+  'polygon',
+  'multilinestring',
+  'multipolygon',
+  'multipoint',
+  'geometry', // not in ogc-client (to avoid unknown type for geometry) 
+] as const;
+
+/**
+ * The type of a property in a collection.
+ * Includes scalar types and geometry types.
+ */
+export type CollectionPropertyType = typeof PROPERTY_TYPES[number];
+
+/**
+ * The set of valid property type values.
+ */
+const VALID_PROPERTY_TYPES: Set<string> = new Set(PROPERTY_TYPES);
+
+/**
+ * Check if a value is a valid CollectionPropertyType.
+ * @param value the value to validate
+ * @returns true if valid, false otherwise
+ */
+export function isValidPropertyType(value: unknown): value is CollectionPropertyType {
+  return typeof value === 'string' && VALID_PROPERTY_TYPES.has(value);
+}
+
+/**
+ * Assert that a value is a valid CollectionPropertyType, throwing UnexpectedTypeError if not.
+ * @param value the value to validate
+ * @param context optional context about where the error occurred
+ * @returns the value if valid
+ * @throws UnexpectedTypeError if invalid
+ */
+export function assertIsValidPropertyType(value: unknown, context?: string): CollectionPropertyType {
+  if (!isValidPropertyType(value)) {
+    throw new UnexpectedTypeError(value, context);
+  }
+  return value;
+}
 
 /**
  * A property of a collection.
@@ -55,7 +127,7 @@ export type CollectionProperty = {
   /**
    * The type of the property.
    */
-  type: string;
+  type: CollectionPropertyType;
   /**
    * The title of the property.
    */


### PR DESCRIPTION
## Summary

This PR implements the core property typing for #25 and enforces it in WFS collection parsing.

## Changes

- Added a strict `CollectionPropertyType` union (scalar + geometry core types).
- Added runtime validation with `isValidPropertyType` / `assertIsValidPropertyType`.
- Added `UnexpectedTypeError` for unsupported property types.
- Updated `WfsClient.getCollection` to validate property and geometry types (with `unknown` mapped to `geometry`).
- Updated merge behavior to always preserve original property `name` and `type`, while allowing other fields from overwrite.
- Updated and extended tests, including rejection on invalid property type.

## Impact
- Stronger type safety and schema consistency.
- Clear failure when a WFS source returns an unsupported type.

## Validation
- `npm run test` passes.

Refs #25