### PR TITLE
Code review before v0.1.4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ignfab/gpf-schema-store",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ignfab/gpf-schema-store",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@camptocamp/ogc-client": "^1.3.0",
@@ -318,9 +318,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -338,9 +335,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -358,9 +352,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -378,9 +369,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -398,9 +386,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -418,9 +403,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1117,9 +1099,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1141,9 +1120,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1165,9 +1141,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1189,9 +1162,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Experimental OGC API Features schema store enriched from Geoplateforme WFS.",
   "license": "MIT",
   "author": "IGNF",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,7 @@ import { Command } from 'commander'
 import { format } from '@fast-csv/format';
 
 import { WfsClient } from './services/wfs'
-import { getDataDir, writeWfsCollection, clearWfsCollections, getNamespaceFilters, loadWfsCollections, getOverwrite, loadCollections } from './services/storage'
+import { getDataDir, replaceWfsCollections, getNamespaceFilters, loadWfsCollections, getOverwrite, loadCollections } from './services/storage'
 import { getMetadataFromNamespace } from './helpers/metadata'
 import { compare } from './helpers/compare';
 import { MiniSearchCollectionSearchEngine } from './search/minisearch-engine';
@@ -56,14 +56,8 @@ program
     }
     console.log(`Details retrieved for ${filteredCollectionsWithProperties.length} collections.`);
 
-    console.log('Clearing existing collections in data/wfs...');
-    clearWfsCollections();
-    console.log('Existing collections cleared from data/wfs.');
-
-    console.log('Saving collections to data/wfs/{namespace}/{name}.json...');
-    for (const collection of filteredCollectionsWithProperties) {
-      writeWfsCollection(collection);
-    }
+    console.log('Replacing local WFS snapshots in data/wfs...');
+    replaceWfsCollections(filteredCollectionsWithProperties);
 
     console.log(`${filteredCollectionsWithProperties.length} collections saved to data/wfs/{namespace}/{name}.json`);
   })

--- a/src/cli/render-catalog.test.ts
+++ b/src/cli/render-catalog.test.ts
@@ -54,4 +54,31 @@ describe('writeRenderedCatalog', () => {
       force: true,
     });
   });
+
+  it('refuses to clean the project root', async () => {
+    const { writeRenderedCatalog } = await import('./render-catalog');
+
+    expect(() => writeRenderedCatalog(collections, '.', { clean: true })).toThrow(
+      /project root/,
+    );
+    expect(fsMocks.rmSync).not.toHaveBeenCalled();
+  });
+
+  it('refuses to clean outside the current project', async () => {
+    const { writeRenderedCatalog } = await import('./render-catalog');
+
+    expect(() => writeRenderedCatalog(collections, '../catalog', { clean: true })).toThrow(
+      /outside the current project/,
+    );
+    expect(fsMocks.rmSync).not.toHaveBeenCalled();
+  });
+
+  it('refuses to clean protected project directories', async () => {
+    const { writeRenderedCatalog } = await import('./render-catalog');
+
+    expect(() => writeRenderedCatalog(collections, 'data/catalog', { clean: true })).toThrow(
+      /protected project directory/,
+    );
+    expect(fsMocks.rmSync).not.toHaveBeenCalled();
+  });
 });

--- a/src/cli/render-catalog.ts
+++ b/src/cli/render-catalog.ts
@@ -1,10 +1,44 @@
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { isAbsolute, join, relative, resolve, sep } from 'node:path';
 
 import type { Collection } from '../types';
 
 export interface RenderCatalogOptions {
   clean?: boolean;
+}
+
+// This is intentionally stupid but simple: block the obvious project-owned
+// top-level directories instead of trying to prove the output path is safe.
+const PROTECTED_TOP_LEVEL_DIRS = new Set([
+  'src',
+  'data',
+  'dist',
+  'node_modules',
+  'coverage',
+  '.github',
+  '.git',
+]);
+
+function assertSafeCleanTarget(outputDir: string): void {
+  const cwd = process.cwd();
+  const relativePath = relative(cwd, outputDir);
+
+  if (relativePath === '') {
+    throw new Error(`Refusing to clean project root: ${outputDir}`);
+  }
+
+  if (
+    relativePath === '..' ||
+    relativePath.startsWith(`..${sep}`) ||
+    isAbsolute(relativePath)
+  ) {
+    throw new Error(`Refusing to clean outside the current project: ${outputDir}`);
+  }
+
+  const topLevelDir = relativePath.split(sep)[0];
+  if (PROTECTED_TOP_LEVEL_DIRS.has(topLevelDir)) {
+    throw new Error(`Refusing to clean protected project directory: ${outputDir}`);
+  }
 }
 
 export function writeRenderedCatalog(
@@ -15,6 +49,7 @@ export function writeRenderedCatalog(
   const resolvedOutputDir = resolve(outputDir);
 
   if (options.clean) {
+    assertSafeCleanTarget(resolvedOutputDir);
     rmSync(resolvedOutputDir, { recursive: true, force: true });
   }
 

--- a/src/services/storage.flush.test.ts
+++ b/src/services/storage.flush.test.ts
@@ -4,6 +4,7 @@ import type { Collection } from '../types'
 const fsMocks = vi.hoisted(() => ({
   existsSync: vi.fn(),
   mkdirSync: vi.fn(),
+  renameSync: vi.fn(),
   rmSync: vi.fn(),
   readFileSync: vi.fn(),
   readdirSync: vi.fn(),
@@ -17,6 +18,7 @@ describe('clearWfsCollections', () => {
     vi.resetModules()
     fsMocks.existsSync.mockReset()
     fsMocks.mkdirSync.mockReset()
+    fsMocks.renameSync.mockReset()
     fsMocks.rmSync.mockReset()
     fsMocks.readFileSync.mockReset()
     fsMocks.readdirSync.mockReset()
@@ -57,5 +59,282 @@ describe('clearWfsCollections', () => {
     const clearOrder = fsMocks.rmSync.mock.invocationCallOrder[0]
     const writeOrder = fsMocks.writeFileSync.mock.invocationCallOrder[0]
     expect(clearOrder).toBeLessThan(writeOrder)
+  })
+})
+
+describe('replaceWfsCollections', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    fsMocks.existsSync.mockReset()
+    fsMocks.mkdirSync.mockReset()
+    fsMocks.renameSync.mockReset()
+    fsMocks.rmSync.mockReset()
+    fsMocks.readFileSync.mockReset()
+    fsMocks.readdirSync.mockReset()
+    fsMocks.writeFileSync.mockReset()
+
+    // resolveDataDir() lookup: src/services/data -> src/data -> data
+    fsMocks.existsSync
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true)
+      .mockReturnValue(false)
+  })
+
+  it('refuses to replace data/wfs with an empty snapshot', async () => {
+    const { replaceWfsCollections } = await import('./storage')
+
+    fsMocks.existsSync.mockClear()
+    fsMocks.mkdirSync.mockClear()
+    fsMocks.renameSync.mockClear()
+    fsMocks.rmSync.mockClear()
+    fsMocks.writeFileSync.mockClear()
+
+    expect(() => replaceWfsCollections([])).toThrow(
+      'Refusing to replace data/wfs with an empty collection snapshot',
+    )
+    expect(fsMocks.existsSync).not.toHaveBeenCalled()
+    expect(fsMocks.mkdirSync).not.toHaveBeenCalled()
+    expect(fsMocks.renameSync).not.toHaveBeenCalled()
+    expect(fsMocks.rmSync).not.toHaveBeenCalled()
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalled()
+  })
+
+  it('writes the replacement snapshot before moving the existing data/wfs directory', async () => {
+    const { replaceWfsCollections } = await import('./storage')
+
+    const collection: Collection = {
+      id: 'NS:feature',
+      namespace: 'NS',
+      name: 'feature',
+      title: 'Feature',
+      description: 'Feature description',
+      properties: [{ name: 'id', type: 'string' }],
+    }
+
+    // recovery sees current data/wfs, namespace directory does not exist in
+    // nextRoot, current data/wfs exists before promotion.
+    fsMocks.existsSync
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true)
+
+    replaceWfsCollections([collection])
+
+    expect(fsMocks.writeFileSync).toHaveBeenCalledWith(
+      expect.stringMatching(/[\\/]data[\\/]\.wfs-next-[^\\/]+[\\/]NS[\\/]feature\.json$/),
+      expect.any(String),
+    )
+    expect(fsMocks.renameSync).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(/[\\/]data[\\/]wfs$/),
+      expect.stringMatching(/[\\/]data[\\/]\.wfs-previous$/),
+    )
+    expect(fsMocks.renameSync).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/[\\/]data[\\/]\.wfs-next-[^\\/]+$/),
+      expect.stringMatching(/[\\/]data[\\/]wfs$/),
+    )
+
+    const writeOrder = fsMocks.writeFileSync.mock.invocationCallOrder[0]
+    const firstRenameOrder = fsMocks.renameSync.mock.invocationCallOrder[0]
+    expect(writeOrder).toBeLessThan(firstRenameOrder)
+    expect(fsMocks.rmSync).not.toHaveBeenCalledWith(
+      expect.stringMatching(/[\\/]data[\\/]wfs$/),
+      expect.anything(),
+    )
+  })
+
+  it('does not move the existing data/wfs directory when writing the replacement fails', async () => {
+    const { replaceWfsCollections } = await import('./storage')
+
+    const collection: Collection = {
+      id: 'NS:feature',
+      namespace: 'NS',
+      name: 'feature',
+      title: 'Feature',
+      description: 'Feature description',
+      properties: [{ name: 'id', type: 'string' }],
+    }
+
+    fsMocks.existsSync
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+    fsMocks.writeFileSync.mockImplementationOnce(() => {
+      throw new Error('disk full')
+    })
+
+    expect(() => replaceWfsCollections([collection])).toThrow('disk full')
+    expect(fsMocks.renameSync).not.toHaveBeenCalled()
+  })
+
+  it('restores the previous snapshot when promoting the replacement fails', async () => {
+    const { replaceWfsCollections } = await import('./storage')
+
+    const collection: Collection = {
+      id: 'NS:feature',
+      namespace: 'NS',
+      name: 'feature',
+      title: 'Feature',
+      description: 'Feature description',
+      properties: [{ name: 'id', type: 'string' }],
+    }
+
+    // recovery sees current data/wfs, namespace directory does not exist in
+    // nextRoot, current data/wfs exists before promotion.
+    fsMocks.existsSync
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true)
+    fsMocks.renameSync
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw new Error('rename failed')
+      })
+      .mockImplementationOnce(() => undefined)
+
+    expect(() => replaceWfsCollections([collection])).toThrow('rename failed')
+    expect(fsMocks.renameSync).toHaveBeenNthCalledWith(
+      3,
+      expect.stringMatching(/[\\/]data[\\/]\.wfs-previous$/),
+      expect.stringMatching(/[\\/]data[\\/]wfs$/),
+    )
+  })
+
+  it('reports both promotion and restore failures when rollback fails', async () => {
+    const { replaceWfsCollections } = await import('./storage')
+
+    const collection: Collection = {
+      id: 'NS:feature',
+      namespace: 'NS',
+      name: 'feature',
+      title: 'Feature',
+      description: 'Feature description',
+      properties: [{ name: 'id', type: 'string' }],
+    }
+
+    // recovery sees current data/wfs, namespace directory does not exist in
+    // nextRoot, current data/wfs exists before promotion.
+    fsMocks.existsSync
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true)
+    fsMocks.renameSync
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw new Error('promotion failed')
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('restore failed')
+      })
+
+    expect(() => replaceWfsCollections([collection])).toThrow(
+      /Failed to promote .* and failed to restore previous snapshot .*restore failed/,
+    )
+    expect(fsMocks.renameSync).toHaveBeenNthCalledWith(
+      3,
+      expect.stringMatching(/[\\/]data[\\/]\.wfs-previous$/),
+      expect.stringMatching(/[\\/]data[\\/]wfs$/),
+    )
+  })
+
+  it('preserves the original failure when temporary snapshot cleanup fails', async () => {
+    const { replaceWfsCollections } = await import('./storage')
+
+    const collection: Collection = {
+      id: 'NS:feature',
+      namespace: 'NS',
+      name: 'feature',
+      title: 'Feature',
+      description: 'Feature description',
+      properties: [{ name: 'id', type: 'string' }],
+    }
+
+    fsMocks.existsSync
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+    fsMocks.writeFileSync.mockImplementationOnce(() => {
+      throw new Error('disk full')
+    })
+    fsMocks.rmSync
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw new Error('cleanup failed')
+      })
+
+    expect(() => replaceWfsCollections([collection])).toThrow('disk full')
+  })
+
+  it('does not fail the update when previous snapshot cleanup fails after promotion', async () => {
+    const { replaceWfsCollections } = await import('./storage')
+
+    const collection: Collection = {
+      id: 'NS:feature',
+      namespace: 'NS',
+      name: 'feature',
+      title: 'Feature',
+      description: 'Feature description',
+      properties: [{ name: 'id', type: 'string' }],
+    }
+
+    // recovery sees current data/wfs, namespace directory does not exist in
+    // nextRoot, current data/wfs exists before promotion.
+    fsMocks.existsSync
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true)
+    fsMocks.rmSync
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => undefined)
+      .mockImplementationOnce(() => {
+        throw new Error('cleanup failed')
+      })
+
+    expect(() => replaceWfsCollections([collection])).not.toThrow()
+    expect(fsMocks.renameSync).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/[\\/]data[\\/]\.wfs-next-[^\\/]+$/),
+      expect.stringMatching(/[\\/]data[\\/]wfs$/),
+    )
+  })
+
+  it('restores an interrupted previous snapshot before writing a new replacement', async () => {
+    const { replaceWfsCollections } = await import('./storage')
+
+    const collection: Collection = {
+      id: 'NS:feature',
+      namespace: 'NS',
+      name: 'feature',
+      title: 'Feature',
+      description: 'Feature description',
+      properties: [{ name: 'id', type: 'string' }],
+    }
+
+    // recovery sees missing data/wfs and existing .wfs-previous, then the new
+    // replacement writes normally.
+    fsMocks.existsSync
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true)
+
+    replaceWfsCollections([collection])
+
+    expect(fsMocks.renameSync).toHaveBeenNthCalledWith(
+      1,
+      expect.stringMatching(/[\\/]data[\\/]\.wfs-previous$/),
+      expect.stringMatching(/[\\/]data[\\/]wfs$/),
+    )
+    expect(fsMocks.renameSync).toHaveBeenNthCalledWith(
+      2,
+      expect.stringMatching(/[\\/]data[\\/]wfs$/),
+      expect.stringMatching(/[\\/]data[\\/]\.wfs-previous$/),
+    )
+    expect(fsMocks.renameSync).toHaveBeenNthCalledWith(
+      3,
+      expect.stringMatching(/[\\/]data[\\/]\.wfs-next-[^\\/]+$/),
+      expect.stringMatching(/[\\/]data[\\/]wfs$/),
+    )
   })
 })

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "url";
 import {
     existsSync,
     mkdirSync,
+    renameSync,
     rmSync,
     readFileSync,
     readdirSync,
@@ -120,18 +121,92 @@ export function loadCollections(): Collection[] {
 }
 
 /**
+ * Save collection to {root}/{namespace}/{name}.json.
+ *
+ * @param root root directory where WFS collections are stored
+ * @param collection 
+ */
+function writeWfsCollectionToRoot(root: string, collection: Collection): void {
+    const namespaceDirPath = join(root, collection.namespace);
+    if (!existsSync(namespaceDirPath)) {
+        mkdirSync(namespaceDirPath, { recursive: true });
+    }
+
+    const collectionPath = join(namespaceDirPath, `${collection.name}.json`);
+    writeFileSync(collectionPath, JSON.stringify(collection, null, 2));
+}
+
+/**
  * Save collection from the GPF WFS to data/wfs/{namespace}/{name}.json
  *
  * @param collection 
  */
 export function writeWfsCollection(collection: Collection): void {
-    const namespaceDirPath = join(DATA_DIR, 'wfs', collection.namespace);
-    if (!existsSync(namespaceDirPath)) {
-        mkdirSync(namespaceDirPath, { recursive: true });
+    writeWfsCollectionToRoot(join(DATA_DIR, 'wfs'), collection);
+}
+
+/**
+ * Replace all WFS collections while keeping the existing snapshot until the
+ * replacement has been fully written.
+ *
+ * @param collections collections to write to data/wfs
+ */
+export function replaceWfsCollections(collections: Collection[]): void {
+    if (collections.length === 0) {
+        throw new Error('Refusing to replace data/wfs with an empty collection snapshot');
     }
 
-    const overwritePath = join(namespaceDirPath, `${collection.name}.json`);
-    writeFileSync(overwritePath, JSON.stringify(collection, null, 2));
+    const wfsRoot = join(DATA_DIR, 'wfs');
+    const nextRoot = join(DATA_DIR, `.wfs-next-${process.pid}-${Date.now()}`);
+    const previousRoot = join(DATA_DIR, '.wfs-previous');
+
+    if (!existsSync(wfsRoot) && existsSync(previousRoot)) {
+        renameSync(previousRoot, wfsRoot);
+    }
+
+    rmSync(nextRoot, { recursive: true, force: true });
+    rmSync(previousRoot, { recursive: true, force: true });
+
+    try {
+        mkdirSync(nextRoot, { recursive: true });
+        for (const collection of collections) {
+            writeWfsCollectionToRoot(nextRoot, collection);
+        }
+
+        const hadPreviousSnapshot = existsSync(wfsRoot);
+        if (hadPreviousSnapshot) {
+            renameSync(wfsRoot, previousRoot);
+        }
+
+        try {
+            renameSync(nextRoot, wfsRoot);
+        } catch (error) {
+            if (hadPreviousSnapshot) {
+                try {
+                    renameSync(previousRoot, wfsRoot);
+                } catch (restoreError) {
+                    throw new Error(
+                        `Failed to promote ${nextRoot} to ${wfsRoot} and failed to restore previous snapshot from ${previousRoot}: ${restoreError instanceof Error ? restoreError.message : String(restoreError)}`,
+                        { cause: error },
+                    );
+                }
+            }
+            throw error;
+        }
+
+        try {
+            rmSync(previousRoot, { recursive: true, force: true });
+        } catch {
+            // The new snapshot is already promoted; retry stale backup cleanup on the next update.
+        }
+    } catch (error) {
+        try {
+            rmSync(nextRoot, { recursive: true, force: true });
+        } catch {
+            // Preserve the original failure; stale temp cleanup can be retried on the next update.
+        }
+        throw error;
+    }
 }
 
 


### PR DESCRIPTION
closes #38

## Summary

- Make `update` replace `data/wfs` through a temporary snapshot directory instead of clearing and rewriting it in place.
- Preserve or restore the previous WFS snapshot when replacement fails.
- Refuse empty WFS snapshots to avoid replacing the catalog with an empty directory.
- Add safety checks for `render-catalog --clean` to avoid deleting project-owned directories.
- Add `.editorconfig` for consistent whitespace and editor defaults.
- Bump package version to `0.1.4`.

## Tests

- `npm run typecheck`
- `npm run test`
- `npm run build`
- `npm pack --dry-run --cache /tmp/npm-cache`
