### PR TITLE
WFS keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 The data model is :
 
-* **id** : WFS GetCap FeatureType `<Name>` (namespace:name = unique identifier) 
+* **id** : WFS GetCap FeatureType `<Name>` (namespace:name = unique identifier)
 * **namespace** : namespace identifier (e.g `BDTOPO_V3`)
 * **name** : name identifier (e.g `batiment`)
 * **title** : WFS GetCap `<Title>` "BDTOPO : Bâtiments"
@@ -28,7 +28,7 @@ npm install
 npm run build
 ```
 
-### Test 
+### Test
 
 ```bash
 # To run unit test only :
@@ -85,6 +85,21 @@ npx gpf-schema-store search bdtopo batiment --limit 3
 ```
 
 The output shows the collection identifier, the computed score, and MiniSearch match details, which makes it easier to compare ranking behavior before and after a search change.
+
+### Inspect WFS keywords
+
+Use the `wfs-keywords` command to request the public GPF WFS directly and list collection keywords sorted by occurrence count.
+
+```bash
+# show normalized keywords from the public GPF WFS
+npx gpf-schema-store wfs-keywords
+
+# show keywords after removing generic values such as "features" and "WFS"
+npx gpf-schema-store wfs-keywords --filtered
+
+# only show the 20 most frequent keywords
+npx gpf-schema-store wfs-keywords --limit 20
+```
 
 ### Render merged catalog files
 

--- a/data/wfs/ADMINEXPRESS-COG.2017/arrondissement_departemental.json
+++ b/data/wfs/ADMINEXPRESS-COG.2017/arrondissement_departemental.json
@@ -4,6 +4,9 @@
   "name": "arrondissement_departemental",
   "title": "ADMINEXPRESS COG 2017 Arrondissement départemental",
   "description": "ADMINEXPRESS COG 2017 Arrondissement départemental",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2017/chef_lieu.json
+++ b/data/wfs/ADMINEXPRESS-COG.2017/chef_lieu.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu",
   "title": "ADMINEXPRESS COG 2017 Chef-lieu",
   "description": "ADMINEXPRESS COG 2017 Chef-lieu",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2017/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2017/commune.json
@@ -4,6 +4,9 @@
   "name": "commune",
   "title": "ADMINEXPRESS COG 2017 Commune",
   "description": "ADMINEXPRESS COG 2017 Commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2017/departement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2017/departement.json
@@ -4,6 +4,9 @@
   "name": "departement",
   "title": "ADMINEXPRESS COG 2017 Département",
   "description": "ADMINEXPRESS COG 2017 Département",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2017/epci.json
+++ b/data/wfs/ADMINEXPRESS-COG.2017/epci.json
@@ -4,6 +4,9 @@
   "name": "epci",
   "title": "ADMINEXPRESS COG 2017 EPCI",
   "description": "ADMINEXPRESS COG 2017 EPCI",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2017/region.json
+++ b/data/wfs/ADMINEXPRESS-COG.2017/region.json
@@ -4,6 +4,9 @@
   "name": "region",
   "title": "ADMINEXPRESS COG 2017 Région",
   "description": "ADMINEXPRESS COG 2017 Région",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2018/arrondissement_departemental.json
+++ b/data/wfs/ADMINEXPRESS-COG.2018/arrondissement_departemental.json
@@ -4,6 +4,9 @@
   "name": "arrondissement_departemental",
   "title": "ADMINEXPRESS COG 2018 Arrondissement départemental",
   "description": "ADMINEXPRESS COG 2018 Arrondissement départemental",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2018/chef_lieu.json
+++ b/data/wfs/ADMINEXPRESS-COG.2018/chef_lieu.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu",
   "title": "ADMINEXPRESS COG 2018 Chef-lieu",
   "description": "ADMINEXPRESS COG 2018 Chef-lieu",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2018/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2018/commune.json
@@ -4,6 +4,9 @@
   "name": "commune",
   "title": "ADMINEXPRESS COG 2018 Commune",
   "description": "ADMINEXPRESS COG 2018 Commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2018/departement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2018/departement.json
@@ -4,6 +4,9 @@
   "name": "departement",
   "title": "ADMINEXPRESS COG 2018 Département",
   "description": "ADMINEXPRESS COG 2018 Département",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2018/epci.json
+++ b/data/wfs/ADMINEXPRESS-COG.2018/epci.json
@@ -4,6 +4,9 @@
   "name": "epci",
   "title": "ADMINEXPRESS COG 2018 EPCI",
   "description": "ADMINEXPRESS COG 2018 EPCI",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2018/region.json
+++ b/data/wfs/ADMINEXPRESS-COG.2018/region.json
@@ -4,6 +4,9 @@
   "name": "region",
   "title": "ADMINEXPRESS COG 2018 Région",
   "description": "ADMINEXPRESS COG 2018 Région",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2019/arrondissement_departemental.json
+++ b/data/wfs/ADMINEXPRESS-COG.2019/arrondissement_departemental.json
@@ -4,6 +4,9 @@
   "name": "arrondissement_departemental",
   "title": "ADMINEXPRESS COG 2019 Arrondissement départemental",
   "description": "ADMINEXPRESS COG 2019 Arrondissement départemental",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2019/chef_lieu.json
+++ b/data/wfs/ADMINEXPRESS-COG.2019/chef_lieu.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu",
   "title": "ADMINEXPRESS COG 2019 Chef-lieu",
   "description": "ADMINEXPRESS COG 2019 Chef-lieu",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2019/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2019/commune.json
@@ -4,6 +4,9 @@
   "name": "commune",
   "title": "ADMINEXPRESS COG 2019 Commune",
   "description": "ADMINEXPRESS COG 2019 Commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2019/departement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2019/departement.json
@@ -4,6 +4,9 @@
   "name": "departement",
   "title": "ADMINEXPRESS COG 2019 Département",
   "description": "ADMINEXPRESS COG 2019 Département",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2019/epci.json
+++ b/data/wfs/ADMINEXPRESS-COG.2019/epci.json
@@ -4,6 +4,9 @@
   "name": "epci",
   "title": "ADMINEXPRESS COG 2019 EPCI",
   "description": "ADMINEXPRESS COG 2019 EPCI",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2019/region.json
+++ b/data/wfs/ADMINEXPRESS-COG.2019/region.json
@@ -4,6 +4,9 @@
   "name": "region",
   "title": "ADMINEXPRESS COG 2019 Région",
   "description": "ADMINEXPRESS COG 2019 Région",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2020/arrondissement_departemental.json
+++ b/data/wfs/ADMINEXPRESS-COG.2020/arrondissement_departemental.json
@@ -4,6 +4,9 @@
   "name": "arrondissement_departemental",
   "title": "ADMINEXPRESS COG 2020 Arrondissement départemental",
   "description": "ADMINEXPRESS COG 2020 Arrondissement départemental",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2020/arrondissement_municipal.json
+++ b/data/wfs/ADMINEXPRESS-COG.2020/arrondissement_municipal.json
@@ -4,6 +4,9 @@
   "name": "arrondissement_municipal",
   "title": "ADMINEXPRESS COG 2020 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2020 Arrondissement municipal",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2020/canton.json
+++ b/data/wfs/ADMINEXPRESS-COG.2020/canton.json
@@ -4,6 +4,9 @@
   "name": "canton",
   "title": "ADMINEXPRESS COG 2020 Canton",
   "description": "ADMINEXPRESS COG 2020 Canton",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2020/chef_lieu.json
+++ b/data/wfs/ADMINEXPRESS-COG.2020/chef_lieu.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu",
   "title": "ADMINEXPRESS COG 2020 Chef-lieu",
   "description": "ADMINEXPRESS COG 2020 Chef-lieu",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2020/chef_lieu_entite_rattachee.json
+++ b/data/wfs/ADMINEXPRESS-COG.2020/chef_lieu_entite_rattachee.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_entite_rattachee",
   "title": "ADMINEXPRESS COG 2020 Chef-lieu entité rattachée",
   "description": "ADMINEXPRESS COG 2020 Chef-lieu entité rattachée",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2020/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2020/commune.json
@@ -4,6 +4,9 @@
   "name": "commune",
   "title": "ADMINEXPRESS COG 2020 Commune",
   "description": "ADMINEXPRESS COG 2020 Commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2020/departement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2020/departement.json
@@ -4,6 +4,9 @@
   "name": "departement",
   "title": "ADMINEXPRESS COG 2020 Département",
   "description": "ADMINEXPRESS COG 2020 Département",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2020/epci.json
+++ b/data/wfs/ADMINEXPRESS-COG.2020/epci.json
@@ -4,6 +4,9 @@
   "name": "epci",
   "title": "ADMINEXPRESS COG 2020 EPCI",
   "description": "ADMINEXPRESS COG 2020 EPCI",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2020/region.json
+++ b/data/wfs/ADMINEXPRESS-COG.2020/region.json
@@ -4,6 +4,9 @@
   "name": "region",
   "title": "ADMINEXPRESS COG 2020 Région",
   "description": "ADMINEXPRESS COG 2020 Région",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2021/arrondissement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2021/arrondissement.json
@@ -4,6 +4,9 @@
   "name": "arrondissement",
   "title": "ADMINEXPRESS COG 2021 Arrondissement",
   "description": "ADMINEXPRESS COG 2021 Arrondissement",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2021/arrondissement_municipal.json
+++ b/data/wfs/ADMINEXPRESS-COG.2021/arrondissement_municipal.json
@@ -4,6 +4,9 @@
   "name": "arrondissement_municipal",
   "title": "ADMINEXPRESS COG 2021 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2021 Arrondissement municipal",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2021/canton.json
+++ b/data/wfs/ADMINEXPRESS-COG.2021/canton.json
@@ -4,6 +4,9 @@
   "name": "canton",
   "title": "ADMINEXPRESS COG 2021 Canton",
   "description": "ADMINEXPRESS COG 2021 Canton",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2021/chef_lieu_arrondissement_municipal.json
+++ b/data/wfs/ADMINEXPRESS-COG.2021/chef_lieu_arrondissement_municipal.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_arrondissement_municipal",
   "title": "ADMINEXPRESS COG 2021 Chef-lieu Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2021 Chef-lieu Arrondissement municipal",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2021/chef_lieu_commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2021/chef_lieu_commune.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_commune",
   "title": "ADMINEXPRESS COG 2021 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2021 Chef-lieu commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2021/chef_lieu_commune_associee_ou_deleguee.json
+++ b/data/wfs/ADMINEXPRESS-COG.2021/chef_lieu_commune_associee_ou_deleguee.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_commune_associee_ou_deleguee",
   "title": "ADMINEXPRESS COG 2021 Chef-lieu Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2021 Chef-lieu Commune associée ou déléguée",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2021/collectivite_territoriale.json
+++ b/data/wfs/ADMINEXPRESS-COG.2021/collectivite_territoriale.json
@@ -4,6 +4,9 @@
   "name": "collectivite_territoriale",
   "title": "ADMINEXPRESS COG 2021 Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2021 Collectivité territoriale",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2021/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2021/commune.json
@@ -4,6 +4,9 @@
   "name": "commune",
   "title": "ADMINEXPRESS COG 2021 Commune",
   "description": "ADMINEXPRESS COG 2021 Commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2021/commune_associee_ou_deleguee.json
+++ b/data/wfs/ADMINEXPRESS-COG.2021/commune_associee_ou_deleguee.json
@@ -4,6 +4,9 @@
   "name": "commune_associee_ou_deleguee",
   "title": "ADMINEXPRESS COG 2021 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2021 Commune associée ou déléguée",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2021/departement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2021/departement.json
@@ -4,6 +4,9 @@
   "name": "departement",
   "title": "ADMINEXPRESS COG 2021 Département",
   "description": "ADMINEXPRESS COG 2021 Département",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2021/epci.json
+++ b/data/wfs/ADMINEXPRESS-COG.2021/epci.json
@@ -4,6 +4,9 @@
   "name": "epci",
   "title": "ADMINEXPRESS COG 2021 EPCI",
   "description": "ADMINEXPRESS COG 2021 EPCI",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2021/region.json
+++ b/data/wfs/ADMINEXPRESS-COG.2021/region.json
@@ -4,6 +4,9 @@
   "name": "region",
   "title": "ADMINEXPRESS COG 2021 Région",
   "description": "ADMINEXPRESS COG 2021 Région",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2022/arrondissement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2022/arrondissement.json
@@ -4,6 +4,9 @@
   "name": "arrondissement",
   "title": "ADMINEXPRESS COG 2022 Arrondissement",
   "description": "ADMINEXPRESS COG 2022 Arrondissement",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2022/arrondissement_municipal.json
+++ b/data/wfs/ADMINEXPRESS-COG.2022/arrondissement_municipal.json
@@ -4,6 +4,9 @@
   "name": "arrondissement_municipal",
   "title": "ADMINEXPRESS COG 2022 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2022 Arrondissement municipal",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2022/canton.json
+++ b/data/wfs/ADMINEXPRESS-COG.2022/canton.json
@@ -4,6 +4,9 @@
   "name": "canton",
   "title": "ADMINEXPRESS COG 2022 Canton",
   "description": "ADMINEXPRESS COG 2022 Canton",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2022/chef_lieu_arrondissement_municipal.json
+++ b/data/wfs/ADMINEXPRESS-COG.2022/chef_lieu_arrondissement_municipal.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_arrondissement_municipal",
   "title": "ADMINEXPRESS COG 2022 Chef-lieu Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2022 Chef-lieu Arrondissement municipal",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2022/chef_lieu_commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2022/chef_lieu_commune.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_commune",
   "title": "ADMINEXPRESS COG 2022 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2022 Chef-lieu commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2022/chef_lieu_commune_associee_ou_deleguee.json
+++ b/data/wfs/ADMINEXPRESS-COG.2022/chef_lieu_commune_associee_ou_deleguee.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_commune_associee_ou_deleguee",
   "title": "ADMINEXPRESS COG 2022 Chef-lieu Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2022 Chef-lieu Commune associée ou déléguée",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2022/collectivite_territoriale.json
+++ b/data/wfs/ADMINEXPRESS-COG.2022/collectivite_territoriale.json
@@ -4,6 +4,9 @@
   "name": "collectivite_territoriale",
   "title": "ADMINEXPRESS COG 2022 Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2022 Collectivité territoriale",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2022/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2022/commune.json
@@ -4,6 +4,9 @@
   "name": "commune",
   "title": "ADMINEXPRESS COG 2022 Commune",
   "description": "ADMINEXPRESS COG 2022 Commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2022/commune_associee_ou_deleguee.json
+++ b/data/wfs/ADMINEXPRESS-COG.2022/commune_associee_ou_deleguee.json
@@ -4,6 +4,9 @@
   "name": "commune_associee_ou_deleguee",
   "title": "ADMINEXPRESS COG 2022 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2022 Commune associée ou déléguée",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2022/departement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2022/departement.json
@@ -4,6 +4,9 @@
   "name": "departement",
   "title": "ADMINEXPRESS COG 2022 Département",
   "description": "ADMINEXPRESS COG 2022 Département",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2022/epci.json
+++ b/data/wfs/ADMINEXPRESS-COG.2022/epci.json
@@ -4,6 +4,9 @@
   "name": "epci",
   "title": "ADMINEXPRESS COG 2022 EPCI",
   "description": "ADMINEXPRESS COG 2022 EPCI",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2022/region.json
+++ b/data/wfs/ADMINEXPRESS-COG.2022/region.json
@@ -4,6 +4,9 @@
   "name": "region",
   "title": "ADMINEXPRESS COG 2022 Région",
   "description": "ADMINEXPRESS COG 2022 Région",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2023/arrondissement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2023/arrondissement.json
@@ -4,6 +4,9 @@
   "name": "arrondissement",
   "title": "ADMINEXPRESS COG 2023 Arrondissement",
   "description": "ADMINEXPRESS COG 2023 Arrondissement",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2023/arrondissement_municipal.json
+++ b/data/wfs/ADMINEXPRESS-COG.2023/arrondissement_municipal.json
@@ -4,6 +4,9 @@
   "name": "arrondissement_municipal",
   "title": "ADMINEXPRESS COG 2023 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2023 Arrondissement municipal",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2023/canton.json
+++ b/data/wfs/ADMINEXPRESS-COG.2023/canton.json
@@ -4,6 +4,9 @@
   "name": "canton",
   "title": "ADMINEXPRESS COG 2023 Canton",
   "description": "ADMINEXPRESS COG 2023 Canton",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2023/chef_lieu_arrondissement_municipal.json
+++ b/data/wfs/ADMINEXPRESS-COG.2023/chef_lieu_arrondissement_municipal.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_arrondissement_municipal",
   "title": "ADMINEXPRESS COG 2023 Chef-lieu Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2023 Chef-lieu Arrondissement municipal",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2023/chef_lieu_commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2023/chef_lieu_commune.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_commune",
   "title": "ADMINEXPRESS COG 2023 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2023 Chef-lieu commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2023/chef_lieu_commune_associee_ou_deleguee.json
+++ b/data/wfs/ADMINEXPRESS-COG.2023/chef_lieu_commune_associee_ou_deleguee.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_commune_associee_ou_deleguee",
   "title": "ADMINEXPRESS COG 2023 Chef-lieu Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2023 Chef-lieu Commune associée ou déléguée",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2023/collectivite_territoriale.json
+++ b/data/wfs/ADMINEXPRESS-COG.2023/collectivite_territoriale.json
@@ -4,6 +4,9 @@
   "name": "collectivite_territoriale",
   "title": "ADMINEXPRESS COG 2023 Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2023 Collectivité territoriale",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2023/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2023/commune.json
@@ -4,6 +4,9 @@
   "name": "commune",
   "title": "ADMINEXPRESS COG 2023 Commune",
   "description": "ADMINEXPRESS COG 2023 Commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2023/commune_associee_ou_deleguee.json
+++ b/data/wfs/ADMINEXPRESS-COG.2023/commune_associee_ou_deleguee.json
@@ -4,6 +4,9 @@
   "name": "commune_associee_ou_deleguee",
   "title": "ADMINEXPRESS COG 2023 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2023 Commune associée ou déléguée",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2023/departement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2023/departement.json
@@ -4,6 +4,9 @@
   "name": "departement",
   "title": "ADMINEXPRESS COG 2023 Département",
   "description": "ADMINEXPRESS COG 2023 Département",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2023/epci.json
+++ b/data/wfs/ADMINEXPRESS-COG.2023/epci.json
@@ -4,6 +4,9 @@
   "name": "epci",
   "title": "ADMINEXPRESS COG 2023 EPCI",
   "description": "ADMINEXPRESS COG 2023 EPCI",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2023/region.json
+++ b/data/wfs/ADMINEXPRESS-COG.2023/region.json
@@ -4,6 +4,9 @@
   "name": "region",
   "title": "ADMINEXPRESS COG 2023 Région",
   "description": "ADMINEXPRESS COG 2023 Région",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2024/arrondissement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2024/arrondissement.json
@@ -4,6 +4,9 @@
   "name": "arrondissement",
   "title": "ADMINEXPRESS COG 2024 Arrondissement",
   "description": "ADMINEXPRESS COG 2024 Arrondissement",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2024/arrondissement_municipal.json
+++ b/data/wfs/ADMINEXPRESS-COG.2024/arrondissement_municipal.json
@@ -4,6 +4,9 @@
   "name": "arrondissement_municipal",
   "title": "ADMINEXPRESS COG 2024 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2024 Arrondissement municipal",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2024/canton.json
+++ b/data/wfs/ADMINEXPRESS-COG.2024/canton.json
@@ -4,6 +4,9 @@
   "name": "canton",
   "title": "ADMINEXPRESS COG 2024 Canton",
   "description": "ADMINEXPRESS COG 2024 Canton",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2024/chef_lieu_arrondissement_municipal.json
+++ b/data/wfs/ADMINEXPRESS-COG.2024/chef_lieu_arrondissement_municipal.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_arrondissement_municipal",
   "title": "ADMINEXPRESS COG 2024 Chef-lieu Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2024 Chef-lieu Arrondissement municipal",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2024/chef_lieu_commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2024/chef_lieu_commune.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_commune",
   "title": "ADMINEXPRESS COG 2024 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2024 Chef-lieu commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2024/chef_lieu_commune_associee_ou_deleguee.json
+++ b/data/wfs/ADMINEXPRESS-COG.2024/chef_lieu_commune_associee_ou_deleguee.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_commune_associee_ou_deleguee",
   "title": "ADMINEXPRESS COG 2024 Chef-lieu Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2024 Chef-lieu Commune associée ou déléguée",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2024/collectivite_territoriale.json
+++ b/data/wfs/ADMINEXPRESS-COG.2024/collectivite_territoriale.json
@@ -4,6 +4,9 @@
   "name": "collectivite_territoriale",
   "title": "ADMINEXPRESS COG 2024 Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2024 Collectivité territoriale",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2024/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2024/commune.json
@@ -4,6 +4,9 @@
   "name": "commune",
   "title": "ADMINEXPRESS COG 2024 Commune",
   "description": "ADMINEXPRESS COG 2024 Commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2024/commune_associee_ou_deleguee.json
+++ b/data/wfs/ADMINEXPRESS-COG.2024/commune_associee_ou_deleguee.json
@@ -4,6 +4,9 @@
   "name": "commune_associee_ou_deleguee",
   "title": "ADMINEXPRESS COG 2024 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2024 Commune associée ou déléguée",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2024/departement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2024/departement.json
@@ -4,6 +4,9 @@
   "name": "departement",
   "title": "ADMINEXPRESS COG 2024 Département",
   "description": "ADMINEXPRESS COG 2024 Département",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2024/epci.json
+++ b/data/wfs/ADMINEXPRESS-COG.2024/epci.json
@@ -4,6 +4,9 @@
   "name": "epci",
   "title": "ADMINEXPRESS COG 2024 EPCI",
   "description": "ADMINEXPRESS COG 2024 EPCI",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2024/region.json
+++ b/data/wfs/ADMINEXPRESS-COG.2024/region.json
@@ -4,6 +4,9 @@
   "name": "region",
   "title": "ADMINEXPRESS COG 2024 Région",
   "description": "ADMINEXPRESS COG 2024 Région",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "id",

--- a/data/wfs/ADMINEXPRESS-COG.2025/arrondissement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/arrondissement.json
@@ -4,6 +4,9 @@
   "name": "arrondissement",
   "title": "ADMINEXPRESS COG 2025 Arrondissement",
   "description": "ADMINEXPRESS COG 2025 Arrondissement",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2025/arrondissement_municipal.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/arrondissement_municipal.json
@@ -4,6 +4,9 @@
   "name": "arrondissement_municipal",
   "title": "ADMINEXPRESS COG 2025 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2025 Arrondissement municipal",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2025/canton.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/canton.json
@@ -4,6 +4,9 @@
   "name": "canton",
   "title": "ADMINEXPRESS COG 2025 Canton",
   "description": "ADMINEXPRESS COG 2025 Canton",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2025/chef_lieu_d_arrondissement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/chef_lieu_d_arrondissement.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_d_arrondissement",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu d'Arrondissement",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu d'Arrondissement",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2025/chef_lieu_d_arrondissement_municipal.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/chef_lieu_d_arrondissement_municipal.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_d_arrondissement_municipal",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu d'Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu d'Arrondissement municipal",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2025/chef_lieu_de_collectivite_territoriale.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/chef_lieu_de_collectivite_territoriale.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_de_collectivite_territoriale",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu de Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu de Collectivité territoriale",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2025/chef_lieu_de_commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/chef_lieu_de_commune.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_de_commune",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu de commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2025/chef_lieu_de_commune_associee_ou_deleguee.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/chef_lieu_de_commune_associee_ou_deleguee.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_de_commune_associee_ou_deleguee",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu de Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu de Commune associée ou déléguée",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2025/chef_lieu_de_departement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/chef_lieu_de_departement.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_de_departement",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu de Département",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu de Département",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2025/chef_lieu_de_region.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/chef_lieu_de_region.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_de_region",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu de Région",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu de Région",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2025/collectivite_territoriale.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/collectivite_territoriale.json
@@ -4,6 +4,9 @@
   "name": "collectivite_territoriale",
   "title": "ADMINEXPRESS COG 2025 Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2025 Collectivité territoriale",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2025/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/commune.json
@@ -4,6 +4,9 @@
   "name": "commune",
   "title": "ADMINEXPRESS COG 2025 Commune",
   "description": "ADMINEXPRESS COG 2025 Commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2025/commune_associee_ou_deleguee.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/commune_associee_ou_deleguee.json
@@ -4,6 +4,9 @@
   "name": "commune_associee_ou_deleguee",
   "title": "ADMINEXPRESS COG 2025 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2025 Commune associée ou déléguée",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2025/departement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/departement.json
@@ -4,6 +4,9 @@
   "name": "departement",
   "title": "ADMINEXPRESS COG 2025 Département",
   "description": "ADMINEXPRESS COG 2025 Département",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2025/epci.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/epci.json
@@ -4,6 +4,9 @@
   "name": "epci",
   "title": "ADMINEXPRESS COG 2025 EPCI",
   "description": "ADMINEXPRESS COG 2025 EPCI",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2025/region.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/region.json
@@ -4,6 +4,9 @@
   "name": "region",
   "title": "ADMINEXPRESS COG 2025 Région",
   "description": "ADMINEXPRESS COG 2025 Région",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2026/arrondissement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/arrondissement.json
@@ -4,6 +4,9 @@
   "name": "arrondissement",
   "title": "ADMINEXPRESS COG 2026 Arrondissement",
   "description": "ADMINEXPRESS COG 2026 Arrondissement",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2026/arrondissement_municipal.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/arrondissement_municipal.json
@@ -4,6 +4,9 @@
   "name": "arrondissement_municipal",
   "title": "ADMINEXPRESS COG 2026 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2026 Arrondissement municipal",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2026/canton.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/canton.json
@@ -4,6 +4,9 @@
   "name": "canton",
   "title": "ADMINEXPRESS COG 2026 Canton",
   "description": "ADMINEXPRESS COG 2026 Canton",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2026/chef_lieu_d_arrondissement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/chef_lieu_d_arrondissement.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_d_arrondissement",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu d'Arrondissement",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu d'Arrondissement",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2026/chef_lieu_d_arrondissement_municipal.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/chef_lieu_d_arrondissement_municipal.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_d_arrondissement_municipal",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu d'Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu d'Arrondissement municipal",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2026/chef_lieu_de_collectivite_territoriale.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/chef_lieu_de_collectivite_territoriale.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_de_collectivite_territoriale",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu de Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu de Collectivité territoriale",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2026/chef_lieu_de_commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/chef_lieu_de_commune.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_de_commune",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu de commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2026/chef_lieu_de_commune_associee_ou_deleguee.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/chef_lieu_de_commune_associee_ou_deleguee.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_de_commune_associee_ou_deleguee",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu de Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu de Commune associée ou déléguée",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2026/chef_lieu_de_departement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/chef_lieu_de_departement.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_de_departement",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu de Département",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu de Département",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2026/chef_lieu_de_region.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/chef_lieu_de_region.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_de_region",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu de Région",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu de Région",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2026/collectivite_territoriale.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/collectivite_territoriale.json
@@ -4,6 +4,9 @@
   "name": "collectivite_territoriale",
   "title": "ADMINEXPRESS COG 2026 Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2026 Collectivité territoriale",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2026/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/commune.json
@@ -4,6 +4,9 @@
   "name": "commune",
   "title": "ADMINEXPRESS COG 2026 Commune",
   "description": "ADMINEXPRESS COG 2026 Commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2026/commune_associee_ou_deleguee.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/commune_associee_ou_deleguee.json
@@ -4,6 +4,9 @@
   "name": "commune_associee_ou_deleguee",
   "title": "ADMINEXPRESS COG 2026 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2026 Commune associée ou déléguée",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2026/departement.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/departement.json
@@ -4,6 +4,9 @@
   "name": "departement",
   "title": "ADMINEXPRESS COG 2026 Département",
   "description": "ADMINEXPRESS COG 2026 Département",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2026/epci.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/epci.json
@@ -4,6 +4,9 @@
   "name": "epci",
   "title": "ADMINEXPRESS COG 2026 EPCI",
   "description": "ADMINEXPRESS COG 2026 EPCI",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.2026/region.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/region.json
@@ -4,6 +4,9 @@
   "name": "region",
   "title": "ADMINEXPRESS COG 2026 Région",
   "description": "ADMINEXPRESS COG 2026 Région",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/arrondissement.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/arrondissement.json
@@ -4,6 +4,9 @@
   "name": "arrondissement",
   "title": "ADMINEXPRESS COG Dernière édition Arrondissement",
   "description": "ADMINEXPRESS COG Dernière édition Arrondissement",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/arrondissement_municipal.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/arrondissement_municipal.json
@@ -4,6 +4,9 @@
   "name": "arrondissement_municipal",
   "title": "ADMINEXPRESS COG Dernière édition Arrondissement municipal",
   "description": "ADMINEXPRESS COG Dernière édition Arrondissement municipal",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/canton.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/canton.json
@@ -4,6 +4,9 @@
   "name": "canton",
   "title": "ADMINEXPRESS COG Dernière édition Canton",
   "description": "ADMINEXPRESS COG Dernière édition Canton",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/chef_lieu_d_arrondissement_municipal.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/chef_lieu_d_arrondissement_municipal.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_d_arrondissement_municipal",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu d Arrondissement municipal",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu d Arrondissement municipal",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/chef_lieu_d_epci.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/chef_lieu_d_epci.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_d_epci",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu d EPCI",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu d EPCI",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/chef_lieu_de_canton.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/chef_lieu_de_canton.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_de_canton",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu de Canton",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu de Canton",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/chef_lieu_de_collectivite_territoriale.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/chef_lieu_de_collectivite_territoriale.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_de_collectivite_territoriale",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu de Collectivite Territoriale",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu de Collectivite Territoriale",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/chef_lieu_de_commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/chef_lieu_de_commune.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_de_commune",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu de commune",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu de commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/chef_lieu_de_commune_associee_ou_deleguee.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/chef_lieu_de_commune_associee_ou_deleguee.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_de_commune_associee_ou_deleguee",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu de commune associée ou déléguée",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu de commune associée ou déléguée",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/chef_lieu_de_region.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/chef_lieu_de_region.json
@@ -4,6 +4,9 @@
   "name": "chef_lieu_de_region",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu de Region",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu de Region",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/collectivite_territoriale.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/collectivite_territoriale.json
@@ -4,6 +4,9 @@
   "name": "collectivite_territoriale",
   "title": "ADMINEXPRESS COG Dernière édition Collectivité territoriale",
   "description": "ADMINEXPRESS COG Dernière édition Collectivité territoriale",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/commune.json
@@ -4,6 +4,9 @@
   "name": "commune",
   "title": "ADMINEXPRESS COG Dernière édition Commune",
   "description": "ADMINEXPRESS COG Dernière édition Commune",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/commune_associee_ou_deleguee.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/commune_associee_ou_deleguee.json
@@ -4,6 +4,9 @@
   "name": "commune_associee_ou_deleguee",
   "title": "ADMINEXPRESS COG Dernière édition Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG Dernière édition Commune associée ou déléguée",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/departement.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/departement.json
@@ -4,6 +4,9 @@
   "name": "departement",
   "title": "ADMINEXPRESS COG Dernière édition Département",
   "description": "ADMINEXPRESS COG Dernière édition Département",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/epci.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/epci.json
@@ -4,6 +4,9 @@
   "name": "epci",
   "title": "ADMINEXPRESS COG Dernière édition EPCI",
   "description": "ADMINEXPRESS COG Dernière édition EPCI",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/region.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/region.json
@@ -4,6 +4,9 @@
   "name": "region",
   "title": "ADMINEXPRESS COG Dernière édition Région",
   "description": "ADMINEXPRESS COG Dernière édition Région",
+  "keywords": [
+    "Unités administratives"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/aerodrome.json
+++ b/data/wfs/BDTOPO_V3/aerodrome.json
@@ -4,6 +4,9 @@
   "name": "aerodrome",
   "title": "BDTOPO : Aérodromes",
   "description": "Aérodromes − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "aerodrome"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/arrondissement.json
+++ b/data/wfs/BDTOPO_V3/arrondissement.json
@@ -4,6 +4,9 @@
   "name": "arrondissement",
   "title": "BDTOPO : Arrondissements",
   "description": "Arrondissements − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "arrondissement"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/arrondissement_municipal.json
+++ b/data/wfs/BDTOPO_V3/arrondissement_municipal.json
@@ -4,6 +4,9 @@
   "name": "arrondissement_municipal",
   "title": "BDTOPO : Arrondissements municipaux",
   "description": "Arrondissements municipaux − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "arrondissement_municipal"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/bassin_versant_topographique.json
+++ b/data/wfs/BDTOPO_V3/bassin_versant_topographique.json
@@ -4,6 +4,9 @@
   "name": "bassin_versant_topographique",
   "title": "BDTOPO : Bassins versants topographiques",
   "description": "Bassins versants topographiques − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "bassin_versant_topographique"
+  ],
   "properties": [
     {
       "name": "liens_vers_cours_d_eau_principal",

--- a/data/wfs/BDTOPO_V3/batiment.json
+++ b/data/wfs/BDTOPO_V3/batiment.json
@@ -4,6 +4,9 @@
   "name": "batiment",
   "title": "BDTOPO : Bâtiments",
   "description": "Bâtiments − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "batiment"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/canalisation.json
+++ b/data/wfs/BDTOPO_V3/canalisation.json
@@ -4,6 +4,9 @@
   "name": "canalisation",
   "title": "BDTOPO : Canalisations",
   "description": "Canalisations − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "canalisation"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/cimetiere.json
+++ b/data/wfs/BDTOPO_V3/cimetiere.json
@@ -4,6 +4,9 @@
   "name": "cimetiere",
   "title": "BDTOPO : Cimetières",
   "description": "Cimetières − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "cimetiere"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/collectivite_territoriale.json
+++ b/data/wfs/BDTOPO_V3/collectivite_territoriale.json
@@ -4,6 +4,9 @@
   "name": "collectivite_territoriale",
   "title": "BDTOPO : Collectivités territoriales",
   "description": "Collectivités territoriales − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "collectivite_territoriale"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/commune.json
+++ b/data/wfs/BDTOPO_V3/commune.json
@@ -4,6 +4,9 @@
   "name": "commune",
   "title": "BDTOPO : Communes",
   "description": "Communes − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "commune"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/commune_associee_ou_deleguee.json
+++ b/data/wfs/BDTOPO_V3/commune_associee_ou_deleguee.json
@@ -4,6 +4,9 @@
   "name": "commune_associee_ou_deleguee",
   "title": "BDTOPO : Communes associées ou déléguées",
   "description": "Communes associées ou déléguées − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "commune_associee_ou_deleguee"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/condominium.json
+++ b/data/wfs/BDTOPO_V3/condominium.json
@@ -4,6 +4,9 @@
   "name": "condominium",
   "title": "BDTOPO : Condominiums",
   "description": "Condominiums − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "condominium"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/construction_lineaire.json
+++ b/data/wfs/BDTOPO_V3/construction_lineaire.json
@@ -4,6 +4,9 @@
   "name": "construction_lineaire",
   "title": "BDTOPO : Constructions linéaires",
   "description": "Constructions linéaires − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "construction_lineaire"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/construction_ponctuelle.json
+++ b/data/wfs/BDTOPO_V3/construction_ponctuelle.json
@@ -4,6 +4,9 @@
   "name": "construction_ponctuelle",
   "title": "BDTOPO : Constructions ponctuelles",
   "description": "Constructions ponctuelles − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "construction_ponctuelle"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/construction_surfacique.json
+++ b/data/wfs/BDTOPO_V3/construction_surfacique.json
@@ -4,6 +4,9 @@
   "name": "construction_surfacique",
   "title": "BDTOPO : Constructions surfaciques",
   "description": "Constructions surfaciques − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "construction_surfacique"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/cours_d_eau.json
+++ b/data/wfs/BDTOPO_V3/cours_d_eau.json
@@ -4,6 +4,9 @@
   "name": "cours_d_eau",
   "title": "BDTOPO : Cours d'eau",
   "description": "Cours d'eau − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "cours_d_eau"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/departement.json
+++ b/data/wfs/BDTOPO_V3/departement.json
@@ -4,6 +4,9 @@
   "name": "departement",
   "title": "BDTOPO : Départements",
   "description": "Départements − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "departement"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/detail_hydrographique.json
+++ b/data/wfs/BDTOPO_V3/detail_hydrographique.json
@@ -4,6 +4,9 @@
   "name": "detail_hydrographique",
   "title": "BDTOPO : Détails hydrographiques",
   "description": "Détails hydrographiques − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "detail_hydrographique"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/detail_orographique.json
+++ b/data/wfs/BDTOPO_V3/detail_orographique.json
@@ -4,6 +4,9 @@
   "name": "detail_orographique",
   "title": "BDTOPO : Détails orographiques",
   "description": "Détails orographiques − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "detail_orographique"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/epci.json
+++ b/data/wfs/BDTOPO_V3/epci.json
@@ -4,6 +4,9 @@
   "name": "epci",
   "title": "BDTOPO : EPCI",
   "description": "EPCI − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "epci"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/equipement_de_transport.json
+++ b/data/wfs/BDTOPO_V3/equipement_de_transport.json
@@ -4,6 +4,9 @@
   "name": "equipement_de_transport",
   "title": "BDTOPO : Équipements de transport",
   "description": "Équipements de transport − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "equipement_de_transport"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/erp.json
+++ b/data/wfs/BDTOPO_V3/erp.json
@@ -4,6 +4,9 @@
   "name": "erp",
   "title": "BDTOPO : ERP",
   "description": "ERP − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "erp"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/foret_publique.json
+++ b/data/wfs/BDTOPO_V3/foret_publique.json
@@ -4,6 +4,9 @@
   "name": "foret_publique",
   "title": "BDTOPO : Forêts publiques",
   "description": "Forêts publiques − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "foret_publique"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/haie.json
+++ b/data/wfs/BDTOPO_V3/haie.json
@@ -4,6 +4,9 @@
   "name": "haie",
   "title": "BDTOPO : Haies",
   "description": "Haies − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "haie"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/itineraire_autre.json
+++ b/data/wfs/BDTOPO_V3/itineraire_autre.json
@@ -4,6 +4,9 @@
   "name": "itineraire_autre",
   "title": "BDTOPO : Autres itinéraires",
   "description": "Autres itinéraires − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "itineraire_autre"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/lieu_dit_non_habite.json
+++ b/data/wfs/BDTOPO_V3/lieu_dit_non_habite.json
@@ -4,6 +4,9 @@
   "name": "lieu_dit_non_habite",
   "title": "BDTOPO : Lieux-dits non habités",
   "description": "Lieux-dits non habités − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "lieu_dit_non_habite"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/ligne_electrique.json
+++ b/data/wfs/BDTOPO_V3/ligne_electrique.json
@@ -4,6 +4,9 @@
   "name": "ligne_electrique",
   "title": "BDTOPO : Lignes électriques",
   "description": "Lignes électriques − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "ligne_electrique"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/ligne_orographique.json
+++ b/data/wfs/BDTOPO_V3/ligne_orographique.json
@@ -4,6 +4,9 @@
   "name": "ligne_orographique",
   "title": "BDTOPO : Lignes orographiques",
   "description": "Lignes orographiques − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "ligne_orographique"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/limite_terre_mer.json
+++ b/data/wfs/BDTOPO_V3/limite_terre_mer.json
@@ -4,6 +4,9 @@
   "name": "limite_terre_mer",
   "title": "BDTOPO : Limites terre-mer",
   "description": "Limites terre-mer − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "limite_terre_mer"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/noeud_hydrographique.json
+++ b/data/wfs/BDTOPO_V3/noeud_hydrographique.json
@@ -4,6 +4,9 @@
   "name": "noeud_hydrographique",
   "title": "BDTOPO : Nœuds hydrographiques",
   "description": "Nœuds hydrographiques − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "noeud_hydrographique"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/non_communication.json
+++ b/data/wfs/BDTOPO_V3/non_communication.json
@@ -4,6 +4,9 @@
   "name": "non_communication",
   "title": "BDTOPO : Non-communications",
   "description": "Non-communications − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "non_communication"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/parc_ou_reserve.json
+++ b/data/wfs/BDTOPO_V3/parc_ou_reserve.json
@@ -4,6 +4,9 @@
   "name": "parc_ou_reserve",
   "title": "BDTOPO : Parcs et réserves",
   "description": "Parcs et réserves − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "parc_ou_reserve"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/piste_d_aerodrome.json
+++ b/data/wfs/BDTOPO_V3/piste_d_aerodrome.json
@@ -4,6 +4,9 @@
   "name": "piste_d_aerodrome",
   "title": "BDTOPO : Pistes d'aérodrome",
   "description": "Pistes d'aérodrome − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "piste_d_aerodrome"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/plan_d_eau.json
+++ b/data/wfs/BDTOPO_V3/plan_d_eau.json
@@ -4,6 +4,9 @@
   "name": "plan_d_eau",
   "title": "BDTOPO : Plans d'eau",
   "description": "Plans d'eau − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "plan_d_eau"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/point_d_acces.json
+++ b/data/wfs/BDTOPO_V3/point_d_acces.json
@@ -4,6 +4,9 @@
   "name": "point_d_acces",
   "title": "BDTOPO : Points d'accès",
   "description": "Points d'accès − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "point_d_acces"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/point_de_repere.json
+++ b/data/wfs/BDTOPO_V3/point_de_repere.json
@@ -4,6 +4,9 @@
   "name": "point_de_repere",
   "title": "BDTOPO : Points de repère",
   "description": "Points de repère − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "point_de_repere"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/point_du_reseau.json
+++ b/data/wfs/BDTOPO_V3/point_du_reseau.json
@@ -4,6 +4,9 @@
   "name": "point_du_reseau",
   "title": "BDTOPO : Points de réseau",
   "description": "Points de réseau − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "point_du_reseau"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/poste_de_transformation.json
+++ b/data/wfs/BDTOPO_V3/poste_de_transformation.json
@@ -4,6 +4,9 @@
   "name": "poste_de_transformation",
   "title": "BDTOPO : Postes de transformation",
   "description": "Postes de transformation − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "poste_de_transformation"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/pylone.json
+++ b/data/wfs/BDTOPO_V3/pylone.json
@@ -4,6 +4,9 @@
   "name": "pylone",
   "title": "BDTOPO : Pylônes",
   "description": "Pylônes − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "pylone"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/region.json
+++ b/data/wfs/BDTOPO_V3/region.json
@@ -4,6 +4,9 @@
   "name": "region",
   "title": "BDTOPO : Régions",
   "description": "Régions − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "region"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/reservoir.json
+++ b/data/wfs/BDTOPO_V3/reservoir.json
@@ -4,6 +4,9 @@
   "name": "reservoir",
   "title": "BDTOPO : Réservoirs",
   "description": "Réservoirs − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "reservoir"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/route_numerotee_ou_nommee.json
+++ b/data/wfs/BDTOPO_V3/route_numerotee_ou_nommee.json
@@ -4,6 +4,9 @@
   "name": "route_numerotee_ou_nommee",
   "title": "BDTOPO : Routes numérotées et routes nommées",
   "description": "Routes numérotées et routes nommées − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "route_numerotee_ou_nommee"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/section_de_points_de_repere.json
+++ b/data/wfs/BDTOPO_V3/section_de_points_de_repere.json
@@ -4,6 +4,9 @@
   "name": "section_de_points_de_repere",
   "title": "BDTOPO : Sections de points de repère",
   "description": "Sections de points de repère − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "section_de_points_de_repere"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/surface_hydrographique.json
+++ b/data/wfs/BDTOPO_V3/surface_hydrographique.json
@@ -4,6 +4,9 @@
   "name": "surface_hydrographique",
   "title": "BDTOPO : Surfaces hydrographiques",
   "description": "Surfaces hydrographiques − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "surface_hydrographique"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/terrain_de_sport.json
+++ b/data/wfs/BDTOPO_V3/terrain_de_sport.json
@@ -4,6 +4,9 @@
   "name": "terrain_de_sport",
   "title": "BDTOPO : Terrains de sport",
   "description": "Terrains de sport − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "terrain_de_sport"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/toponymie.json
+++ b/data/wfs/BDTOPO_V3/toponymie.json
@@ -4,6 +4,9 @@
   "name": "toponymie",
   "title": "BDTOPO : Toponymies",
   "description": "Toponymies − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "toponymie"
+  ],
   "properties": [
     {
       "name": "classe_de_l_objet",

--- a/data/wfs/BDTOPO_V3/transport_par_cable.json
+++ b/data/wfs/BDTOPO_V3/transport_par_cable.json
@@ -4,6 +4,9 @@
   "name": "transport_par_cable",
   "title": "BDTOPO : Transports par câble",
   "description": "Transports par câble − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "transport_par_cable"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/troncon_de_route.json
+++ b/data/wfs/BDTOPO_V3/troncon_de_route.json
@@ -4,6 +4,9 @@
   "name": "troncon_de_route",
   "title": "BDTOPO : Tronçons de route",
   "description": "Tronçons de route − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "troncon_de_route"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/troncon_de_voie_ferree.json
+++ b/data/wfs/BDTOPO_V3/troncon_de_voie_ferree.json
@@ -4,6 +4,9 @@
   "name": "troncon_de_voie_ferree",
   "title": "BDTOPO : Tronçons de voie ferrée",
   "description": "Tronçons de voie ferrée − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "troncon_de_voie_ferree"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/troncon_hydrographique.json
+++ b/data/wfs/BDTOPO_V3/troncon_hydrographique.json
@@ -4,6 +4,9 @@
   "name": "troncon_hydrographique",
   "title": "BDTOPO : Tronçons hydrographiques",
   "description": "Tronçons hydrographiques − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "troncon_hydrographique"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/voie_ferree_nommee.json
+++ b/data/wfs/BDTOPO_V3/voie_ferree_nommee.json
@@ -4,6 +4,9 @@
   "name": "voie_ferree_nommee",
   "title": "BDTOPO : Voies ferrées nommées",
   "description": "Voies ferrées nommées − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "voie_ferree_nommee"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/voie_nommee.json
+++ b/data/wfs/BDTOPO_V3/voie_nommee.json
@@ -4,6 +4,9 @@
   "name": "voie_nommee",
   "title": "BDTOPO : Voies nommées",
   "description": "Voies nommées − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "voie_nommee"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/zone_d_activite_ou_d_interet.json
+++ b/data/wfs/BDTOPO_V3/zone_d_activite_ou_d_interet.json
@@ -4,6 +4,9 @@
   "name": "zone_d_activite_ou_d_interet",
   "title": "BDTOPO : Zones d'activité et zones d'intérêt",
   "description": "Zones d'activité et zones d'intérêt − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "zone_d_activite_ou_d_interet"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/zone_d_estran.json
+++ b/data/wfs/BDTOPO_V3/zone_d_estran.json
@@ -4,6 +4,9 @@
   "name": "zone_d_estran",
   "title": "BDTOPO : Zones d'estran",
   "description": "Zones d'estran − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "zone_d_estran"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/zone_d_habitation.json
+++ b/data/wfs/BDTOPO_V3/zone_d_habitation.json
@@ -4,6 +4,9 @@
   "name": "zone_d_habitation",
   "title": "BDTOPO : Zones d'habitation",
   "description": "Zones d'habitation − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "zone_d_habitation"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/BDTOPO_V3/zone_de_vegetation.json
+++ b/data/wfs/BDTOPO_V3/zone_de_vegetation.json
@@ -4,6 +4,9 @@
   "name": "zone_de_vegetation",
   "title": "BDTOPO : Zones de végétation",
   "description": "Zones de végétation − BDTOPO® V3 2026-03-15",
+  "keywords": [
+    "zone_de_vegetation"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/arrondissement.json
+++ b/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/arrondissement.json
@@ -4,6 +4,9 @@
   "name": "arrondissement",
   "title": "PCI Vecteur : Arrondissements",
   "description": "Arrondissements",
+  "keywords": [
+    "arrondissement"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/batiment.json
+++ b/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/batiment.json
@@ -4,6 +4,9 @@
   "name": "batiment",
   "title": "PCI Vecteur : Bâtiments",
   "description": "Bâtiments",
+  "keywords": [
+    "batiment"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/borne_limite_propriete.json
+++ b/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/borne_limite_propriete.json
@@ -4,6 +4,9 @@
   "name": "borne_limite_propriete",
   "title": "PCI Vecteur : Bornes de limite de propriété",
   "description": "Bornes de limite de propriété",
+  "keywords": [
+    "borne_limite_propriete"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/borne_parcelle.json
+++ b/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/borne_parcelle.json
@@ -4,6 +4,9 @@
   "name": "borne_parcelle",
   "title": "PCI Vecteur : Lien bornes parcelles",
   "description": "Lien bornes parcelles",
+  "keywords": [
+    "borne_parcelle"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/commune.json
+++ b/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/commune.json
@@ -4,6 +4,9 @@
   "name": "commune",
   "title": "PCI Vecteur : Communes",
   "description": "Communes",
+  "keywords": [
+    "commune"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/feuille.json
+++ b/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/feuille.json
@@ -4,6 +4,9 @@
   "name": "feuille",
   "title": "PCI Vecteur : Feuilles",
   "description": "Feuilles",
+  "keywords": [
+    "feuille"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/localisant.json
+++ b/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/localisant.json
@@ -4,6 +4,9 @@
   "name": "localisant",
   "title": "PCI Vecteur : Localisants",
   "description": "Localisants",
+  "keywords": [
+    "localisant"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/parcelle.json
+++ b/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/parcelle.json
@@ -4,6 +4,9 @@
   "name": "parcelle",
   "title": "PCI Vecteur : Parcelles",
   "description": "Parcelles",
+  "keywords": [
+    "parcelle"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/subdivision_fiscale.json
+++ b/data/wfs/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/subdivision_fiscale.json
@@ -4,6 +4,9 @@
   "name": "subdivision_fiscale",
   "title": "PCI Vecteur : Subdivisions fiscales",
   "description": "Subdivisions fiscales",
+  "keywords": [
+    "subdivision_fiscale"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/INSEE.FILOSOFI.INDICATORS/carreaux_1km.json
+++ b/data/wfs/INSEE.FILOSOFI.INDICATORS/carreaux_1km.json
@@ -4,6 +4,9 @@
   "name": "carreaux_1km",
   "title": "Carroyages INSEE",
   "description": "Carroyages INSEE à 200 m, à 1 km et à la plus grande échelle diffusable ",
+  "keywords": [
+    "Statistiques"
+  ],
   "properties": [
     {
       "name": "id_inspire",

--- a/data/wfs/INSEE.FILOSOFI.INDICATORS/carreaux_200m.json
+++ b/data/wfs/INSEE.FILOSOFI.INDICATORS/carreaux_200m.json
@@ -4,6 +4,9 @@
   "name": "carreaux_200m",
   "title": "Carroyages INSEE",
   "description": "Carroyages INSEE à 200 m, à 1 km et à la plus grande échelle diffusable ",
+  "keywords": [
+    "Statistiques"
+  ],
   "properties": [
     {
       "name": "id_inspire",

--- a/data/wfs/STATISTICALUNITS.IRIS.PE/contours_iris_pe.json
+++ b/data/wfs/STATISTICALUNITS.IRIS.PE/contours_iris_pe.json
@@ -4,6 +4,9 @@
   "name": "contours_iris_pe",
   "title": "CONTOURS IRIS PE",
   "description": "Contours géométriques des IRIS de l'INSEE",
+  "keywords": [
+    "Statistiques"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/STATISTICALUNITS.IRIS/contours_iris.json
+++ b/data/wfs/STATISTICALUNITS.IRIS/contours_iris.json
@@ -4,6 +4,9 @@
   "name": "contours_iris",
   "title": "CONTOURS IRIS",
   "description": "Contours géométriques des IRIS de l'INSEE",
+  "keywords": [
+    "Statistiques"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/STATISTICALUNITS.IRISGE/iris_ge.json
+++ b/data/wfs/STATISTICALUNITS.IRISGE/iris_ge.json
@@ -4,6 +4,9 @@
   "name": "iris_ge",
   "title": "IRIS Grande Echelle",
   "description": "Contours géométriques des IRIS de l'INSEE à grande échelle sur toute la France ; Edition : 2025-01-01",
+  "keywords": [
+    "Statistiques"
+  ],
   "properties": [
     {
       "name": "cleabs",

--- a/data/wfs/wfs_du/doc_urba.json
+++ b/data/wfs/wfs_du/doc_urba.json
@@ -4,6 +4,12 @@
   "name": "doc_urba",
   "title": "Document d'urbanisme",
   "description": "Classe sémantique décrivant le document d'urbanisme, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "document d'urbanisme",
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_du/doc_urba_com.json
+++ b/data/wfs/wfs_du/doc_urba_com.json
@@ -4,6 +4,12 @@
   "name": "doc_urba_com",
   "title": "Document d'urbanisme",
   "description": "Classe sémantique décrivant le document d'urbanisme, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "document d'urbanisme",
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_du/document.json
+++ b/data/wfs/wfs_du/document.json
@@ -4,6 +4,12 @@
   "name": "document",
   "title": "Document d'urbanisme",
   "description": "Emprise du document d'urbanisme, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "document d'urbanisme",
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_du/habillage_lin.json
+++ b/data/wfs/wfs_du/habillage_lin.json
@@ -4,6 +4,12 @@
   "name": "habillage_lin",
   "title": "Habillages linéaires",
   "description": "Objet linéaire indicatif porté sur le document d'urbanisme pour l'habillage du plan, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "document d'urbanisme",
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_du/habillage_pct.json
+++ b/data/wfs/wfs_du/habillage_pct.json
@@ -4,6 +4,12 @@
   "name": "habillage_pct",
   "title": "Habillages ponctuels",
   "description": "Objet ponctuel indicatif porté sur le document d'urbanisme pour l'habillage du plan, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "document d'urbanisme",
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_du/habillage_surf.json
+++ b/data/wfs/wfs_du/habillage_surf.json
@@ -4,6 +4,12 @@
   "name": "habillage_surf",
   "title": "Habillages surfaciques",
   "description": "Objet surfacique indicatif porté sur le document d'urbanisme pour l'habillage du plan, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "document d'urbanisme",
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_du/habillage_txt.json
+++ b/data/wfs/wfs_du/habillage_txt.json
@@ -4,6 +4,12 @@
   "name": "habillage_txt",
   "title": "Etiquette ponctuelle de l’habillage du plan",
   "description": "Étiquette ponctuelle portée sur le document d'urbanisme pour l’habillage du plan, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "document d'urbanisme",
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_du/info_lin.json
+++ b/data/wfs/wfs_du/info_lin.json
@@ -4,6 +4,12 @@
   "name": "info_lin",
   "title": "Informations linéaires",
   "description": "Périmètre linéaire à reporter à titre d’information, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "document d'urbanisme",
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_du/info_pct.json
+++ b/data/wfs/wfs_du/info_pct.json
@@ -4,6 +4,12 @@
   "name": "info_pct",
   "title": "Informations ponctuelles",
   "description": "Périmètre ponctuel à reporter à titre d’information, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "document d'urbanisme",
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_du/info_surf.json
+++ b/data/wfs/wfs_du/info_surf.json
@@ -4,6 +4,12 @@
   "name": "info_surf",
   "title": "Informations surfaciques",
   "description": "Périmètre surfacique à reporter à titre d’information, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "document d'urbanisme",
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_du/mec.json
+++ b/data/wfs/wfs_du/mec.json
@@ -4,6 +4,11 @@
   "name": "mec",
   "title": "Mise en compatibilité",
   "description": "Mise en compatibilité",
+  "keywords": [
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_du/municipality.json
+++ b/data/wfs/wfs_du/municipality.json
@@ -4,6 +4,11 @@
   "name": "municipality",
   "title": "Communes",
   "description": "Emprise communale, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "insee",

--- a/data/wfs/wfs_du/prescription_lin.json
+++ b/data/wfs/wfs_du/prescription_lin.json
@@ -4,6 +4,12 @@
   "name": "prescription_lin",
   "title": "Prescriptions linéaires",
   "description": "Prescriptions linéaires se superposant au zonage, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "document d'urbanisme",
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_du/prescription_pct.json
+++ b/data/wfs/wfs_du/prescription_pct.json
@@ -4,6 +4,12 @@
   "name": "prescription_pct",
   "title": "Prescriptions ponctuelles",
   "description": "Prescriptions ponctuelles se superposant au zonage, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "document d'urbanisme",
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_du/prescription_surf.json
+++ b/data/wfs/wfs_du/prescription_surf.json
@@ -4,6 +4,12 @@
   "name": "prescription_surf",
   "title": "Prescriptions surfaciques",
   "description": "Prescriptions surfaciques se superposant au zonage, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "document d'urbanisme",
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_du/secteur_cc.json
+++ b/data/wfs/wfs_du/secteur_cc.json
@@ -4,6 +4,12 @@
   "name": "secteur_cc",
   "title": "Secteurs de la carte communale",
   "description": "Secteurs de carte communale, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "document d'urbanisme",
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_du/zone_urba.json
+++ b/data/wfs/wfs_du/zone_urba.json
@@ -4,6 +4,12 @@
   "name": "zone_urba",
   "title": "Zonage du document d'urbanisme",
   "description": "Zonage du document d'urbanisme, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "document d'urbanisme",
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_scot/doc_urba.json
+++ b/data/wfs/wfs_scot/doc_urba.json
@@ -4,6 +4,12 @@
   "name": "doc_urba",
   "title": "Document d'urbanisme",
   "description": "Classe sémantique décrivant le Schéma de Cohérence Territorial, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "urbanisme",
+    "planningCadastre",
+    "SCOT",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_scot/doc_urba_com.json
+++ b/data/wfs/wfs_scot/doc_urba_com.json
@@ -4,6 +4,12 @@
   "name": "doc_urba_com",
   "title": "Document d'urbanisme",
   "description": "Relations entre le Schéma de Cohérence Territorial et les communes auxquelles il s'applique, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "urbanisme",
+    "planningCadastre",
+    "SCOT",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_scot/perimetre_scot.json
+++ b/data/wfs/wfs_scot/perimetre_scot.json
@@ -4,6 +4,12 @@
   "name": "perimetre_scot",
   "title": "Perimetre du Schéma de cohérence territorial",
   "description": "Périmètre publié du Schéma de Cohérence Territorial, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "urbanisme",
+    "planningCadastre",
+    "SCOT",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_scot/scot.json
+++ b/data/wfs/wfs_scot/scot.json
@@ -4,6 +4,12 @@
   "name": "scot",
   "title": "Schéma de cohérence territorial",
   "description": "Etat du Schéma de Cohérence Territorial, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "urbanisme",
+    "planningCadastre",
+    "SCOT",
+    "usage des sols"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_sup/acte_sup.json
+++ b/data/wfs/wfs_sup/acte_sup.json
@@ -4,6 +4,12 @@
   "name": "acte_sup",
   "title": "Acte de servitude d'utilité publique",
   "description": "Liste des actes instituant une servitude d'utilité publique, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols",
+    "SUP"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_sup/assiette_sup_l.json
+++ b/data/wfs/wfs_sup/assiette_sup_l.json
@@ -4,6 +4,12 @@
   "name": "assiette_sup_l",
   "title": "Assiette de servitude d'utilité publique",
   "description": "Assiettes linéaires liées aux servitudes, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols",
+    "SUP"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_sup/assiette_sup_p.json
+++ b/data/wfs/wfs_sup/assiette_sup_p.json
@@ -4,6 +4,12 @@
   "name": "assiette_sup_p",
   "title": "Assiette de servitude d'utilité publique",
   "description": "Assiettes ponctuelles liées aux servitudes, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols",
+    "SUP"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_sup/assiette_sup_s.json
+++ b/data/wfs/wfs_sup/assiette_sup_s.json
@@ -4,6 +4,12 @@
   "name": "assiette_sup_s",
   "title": "Assiette de servitude d'utilité publique",
   "description": "Assiettes surfaciques liées aux servitudes, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols",
+    "SUP"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_sup/generateur_sup_l.json
+++ b/data/wfs/wfs_sup/generateur_sup_l.json
@@ -4,6 +4,12 @@
   "name": "generateur_sup_l",
   "title": "Générateur de servitude d'utilité publique",
   "description": "Générateurs linéaires liés aux servitudes, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols",
+    "SUP"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_sup/generateur_sup_p.json
+++ b/data/wfs/wfs_sup/generateur_sup_p.json
@@ -4,6 +4,12 @@
   "name": "generateur_sup_p",
   "title": "Générateur de servitude d'utilité publique",
   "description": "Générateurs ponctuels liés aux servitudes, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols",
+    "SUP"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_sup/generateur_sup_s.json
+++ b/data/wfs/wfs_sup/generateur_sup_s.json
@@ -4,6 +4,12 @@
   "name": "generateur_sup_s",
   "title": "Générateur de servitude d'utilité publique",
   "description": "Générateurs surfaciques liés aux servitudes, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols",
+    "SUP"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_sup/gestionnaire_sup.json
+++ b/data/wfs/wfs_sup/gestionnaire_sup.json
@@ -4,6 +4,12 @@
   "name": "gestionnaire_sup",
   "title": "Organisme gestionnaire ou organisme ressource de la servitude",
   "description": "Gestionnaires de servitude d'utilité publique, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols",
+    "SUP"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_sup/servitude.json
+++ b/data/wfs/wfs_sup/servitude.json
@@ -4,6 +4,12 @@
   "name": "servitude",
   "title": "Servitude d'utilité publique",
   "description": "Liste des servitudes d'utilité publique, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols",
+    "SUP"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/data/wfs/wfs_sup/servitude_acte_sup.json
+++ b/data/wfs/wfs_sup/servitude_acte_sup.json
@@ -4,6 +4,12 @@
   "name": "servitude_acte_sup",
   "title": "Relation entre ACTE_SUP et SERVITUDE",
   "description": "Relation entre les SUP et les actes les instituant, données issues du Géoportail de l'urbanisme",
+  "keywords": [
+    "urbanisme",
+    "planningCadastre",
+    "usage des sols",
+    "SUP"
+  ],
   "properties": [
     {
       "name": "gid",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ignfab/gpf-schema-store",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ignfab/gpf-schema-store",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@camptocamp/ogc-client": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Experimental OGC API Features schema store enriched from Geoplateforme WFS.",
   "license": "MIT",
   "author": "IGNF",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url'
 import { Command } from 'commander'
 
 import { format } from '@fast-csv/format';
+import { WfsEndpoint } from '@camptocamp/ogc-client';
 
 import { WfsClient } from './services/wfs'
 import { getDataDir, replaceWfsCollections, getNamespaceFilters, loadWfsCollections, getOverwrite, loadCollections } from './services/storage'
@@ -13,6 +14,7 @@ import { compare } from './helpers/compare';
 import { MiniSearchCollectionSearchEngine } from './search/minisearch-engine';
 import { renderSearchOutputs } from './cli/search-outputs';
 import { writeRenderedCatalog } from './cli/render-catalog';
+import { filterCollectionKeywords, getKeywordOccurrences, normalizeCollectionKeywords } from './helpers/keywords';
 import type { Collection } from './types';
 
 const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json')
@@ -26,6 +28,20 @@ program
   .version(version)
 
 const GPF_WFS_URL = "https://data.geopf.fr/wfs";
+
+async function getWfsKeywordCollections(filtered: boolean): Promise<Array<{ keywords?: string[] }>> {
+  const endpoint = new WfsEndpoint(GPF_WFS_URL);
+  await endpoint.isReady();
+
+  return endpoint.getFeatureTypes().map((featureType) => {
+    const rawKeywords = endpoint.getFeatureTypeSummary(featureType.name)?.keywords;
+    const keywords = filtered
+      ? filterCollectionKeywords(rawKeywords)
+      : normalizeCollectionKeywords(rawKeywords);
+
+    return keywords?.length ? { keywords } : {};
+  });
+}
 
 program
   .command('update')
@@ -175,6 +191,38 @@ program
     const matches = engine.searchDetailed(query).slice(0, limit);
     for (const line of renderSearchOutputs(engine, query, matches)) {
       console.log(line);
+    }
+  })
+
+program
+  .command('wfs-keywords')
+  .alias('wfsKeywords')
+  .description('List collection keywords sorted by occurrence count')
+  .option('-l, --limit <number>', 'Maximum number of keywords to display (defaults to all)')
+  .option('--filtered', 'Apply the application generic keyword filter before counting')
+  .action(async (options: { limit?: string; filtered?: boolean }) => {
+    const limit = options.limit === undefined ? undefined : Number.parseInt(options.limit, 10);
+    if (limit !== undefined && (!Number.isInteger(limit) || limit < 0)) {
+      throw new Error(`Invalid limit '${options.limit}': expected a non-negative integer`);
+    }
+
+    const filtered = options.filtered ?? false;
+    const collections = await getWfsKeywordCollections(filtered);
+    const occurrences = getKeywordOccurrences(collections, { includeGeneric: !filtered });
+    const displayedOccurrences = limit === undefined || limit === 0 ? occurrences : occurrences.slice(0, limit);
+    const countWidth = Math.max('COUNT'.length, ...displayedOccurrences.map((entry) => String(entry.count).length));
+
+    console.log(`source: ${GPF_WFS_URL}`);
+    console.log(`filter: ${filtered ? 'generic keywords removed' : 'normalized keywords'}`);
+    console.log(`keywords: ${occurrences.length}`);
+    console.log('');
+    console.log(`${'COUNT'.padStart(countWidth)}  KEYWORD`);
+
+    for (const occurrence of displayedOccurrences) {
+      console.log([
+        String(occurrence.count).padStart(countWidth),
+        occurrence.keyword,
+      ].join('  '));
     }
   })
 

--- a/src/helpers/keywords.test.ts
+++ b/src/helpers/keywords.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  filterCollectionKeywords,
+  getKeywordOccurrences,
+  isGenericCollectionKeyword,
+  normalizeCollectionKeywords,
+} from './keywords';
+
+describe('collection keywords helpers', () => {
+  it('identifies generic collection keywords', () => {
+    expect(isGenericCollectionKeyword('DEMO')).toBe(true);
+    expect(isGenericCollectionKeyword('feature')).toBe(true);
+    expect(isGenericCollectionKeyword('features')).toBe(true);
+    expect(isGenericCollectionKeyword('géoplateforme')).toBe(true);
+    expect(isGenericCollectionKeyword('Tutoriel')).toBe(true);
+    expect(isGenericCollectionKeyword('WFS')).toBe(true);
+    expect(isGenericCollectionKeyword('occupation du sol')).toBe(false);
+  });
+
+  it('filters generic keywords, empty values and duplicates', () => {
+    expect(filterCollectionKeywords([
+      ' features ',
+      'WFS',
+      'DEMO',
+      'Test',
+      '',
+      'Occupation du sol',
+      'occupation du sol',
+      'Urbanisme',
+    ])).toEqual(['Occupation du sol', 'Urbanisme']);
+  });
+
+  it('can normalize keywords without removing generic values', () => {
+    expect(normalizeCollectionKeywords([
+      ' features ',
+      'WFS',
+      '',
+      'Occupation du sol',
+      'occupation du sol',
+    ])).toEqual(['features', 'WFS', 'Occupation du sol']);
+  });
+
+  it('sorts keyword occurrences by count then keyword', () => {
+    expect(getKeywordOccurrences([
+      { keywords: ['features', 'Urbanisme', 'WFS'] },
+      { keywords: ['urbanisme', 'Occupation du sol'] },
+      { keywords: ['Features', 'Occupation du sol'] },
+    ])).toEqual([
+      { keyword: 'features', count: 2 },
+      { keyword: 'Occupation du sol', count: 2 },
+      { keyword: 'Urbanisme', count: 2 },
+      { keyword: 'WFS', count: 1 },
+    ]);
+  });
+
+  it('can exclude generic keyword occurrences', () => {
+    expect(getKeywordOccurrences([
+      { keywords: ['features', 'Urbanisme', 'WFS'] },
+      { keywords: ['urbanisme', 'Occupation du sol'] },
+    ], { includeGeneric: false })).toEqual([
+      { keyword: 'Urbanisme', count: 2 },
+      { keyword: 'Occupation du sol', count: 1 },
+    ]);
+  });
+});

--- a/src/helpers/keywords.ts
+++ b/src/helpers/keywords.ts
@@ -1,0 +1,109 @@
+import type { Collection, CollectionBrief } from '../types';
+
+const GENERIC_COLLECTION_KEYWORDS = new Set([
+  'dataset',
+  'demo',
+  'feature',
+  'features',
+  'geoplateforme',
+  'important',
+  'keywordwfs',
+  'produits',
+  'qgis',
+  'recette',
+  'test',
+  'tutoriel',
+  'vecteur',
+  'wfs',
+]);
+
+type KeywordSource = Pick<Collection | CollectionBrief, 'keywords'>;
+
+export type KeywordOccurrence = {
+  keyword: string;
+  count: number;
+};
+
+function normalizeKeyword(keyword: string): string {
+  return keyword
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .trim();
+}
+
+export function isGenericCollectionKeyword(keyword: string): boolean {
+  return GENERIC_COLLECTION_KEYWORDS.has(normalizeKeyword(keyword));
+}
+
+function cleanCollectionKeywords(
+  keywords: string[] | undefined,
+  options: { includeGeneric: boolean },
+): string[] | undefined {
+  if (!keywords) {
+    return undefined;
+  }
+
+  const cleanedKeywords: string[] = [];
+  const seen = new Set<string>();
+  for (const keyword of keywords) {
+    const trimmedKeyword = keyword.trim();
+    const normalizedKeyword = normalizeKeyword(trimmedKeyword);
+    const generic = isGenericCollectionKeyword(trimmedKeyword);
+    if (!trimmedKeyword || (!options.includeGeneric && generic) || seen.has(normalizedKeyword)) {
+      continue;
+    }
+    seen.add(normalizedKeyword);
+    cleanedKeywords.push(trimmedKeyword);
+  }
+
+  return cleanedKeywords.length > 0 ? cleanedKeywords : undefined;
+}
+
+export function normalizeCollectionKeywords(keywords: string[] | undefined): string[] | undefined {
+  return cleanCollectionKeywords(keywords, { includeGeneric: true });
+}
+
+export function filterCollectionKeywords(keywords: string[] | undefined): string[] | undefined {
+  return cleanCollectionKeywords(keywords, { includeGeneric: false });
+}
+
+export function getKeywordOccurrences(
+  collections: KeywordSource[],
+  options: { includeGeneric?: boolean } = {},
+): KeywordOccurrence[] {
+  const includeGeneric = options.includeGeneric ?? true;
+  const occurrences = new Map<string, KeywordOccurrence>();
+
+  for (const collection of collections) {
+    for (const keyword of collection.keywords ?? []) {
+      const trimmedKeyword = keyword.trim();
+      if (!trimmedKeyword) {
+        continue;
+      }
+
+      const normalizedKeyword = normalizeKeyword(trimmedKeyword);
+      const generic = isGenericCollectionKeyword(trimmedKeyword);
+      if (generic && !includeGeneric) {
+        continue;
+      }
+
+      const occurrence = occurrences.get(normalizedKeyword);
+      if (occurrence) {
+        occurrence.count += 1;
+      } else {
+        occurrences.set(normalizedKeyword, {
+          keyword: trimmedKeyword,
+          count: 1,
+        });
+      }
+    }
+  }
+
+  return [...occurrences.values()].sort((left, right) => {
+    if (left.count !== right.count) {
+      return right.count - left.count;
+    }
+    return left.keyword.localeCompare(right.keyword);
+  });
+}

--- a/src/helpers/merge.test.ts
+++ b/src/helpers/merge.test.ts
@@ -122,6 +122,21 @@ describe('mergeCollectionSchema', () => {
     expect(merge(base, overwrite).description).toEqual(base.description)
   })
 
+  it('keeps original keywords only when they are present', () => {
+    const original: Collection = {
+      ...base,
+      keywords: ['transport'],
+    }
+    const overwrite: Collection = {
+      ...base,
+      title: 'Modified title',
+      keywords: ['ignored'],
+    }
+
+    expect(merge(original, overwrite).keywords).toEqual(['transport'])
+    expect(merge(base, overwrite)).not.toHaveProperty('keywords')
+  })
+
   it('keeps geometry properties from original when they define defaultCrs', () => {
     const baseWithGeometry: Collection = {
       ...base,

--- a/src/helpers/merge.ts
+++ b/src/helpers/merge.ts
@@ -58,6 +58,7 @@ export function merge(
         name: original.name,
         title: overwrite.title,
         description: overwrite.description,
+        ...(original.keywords?.length ? { keywords: original.keywords } : {}),
         properties
     }
 }

--- a/src/search/minisearch-engine.test.ts
+++ b/src/search/minisearch-engine.test.ts
@@ -231,3 +231,46 @@ describe('MiniSearchCollectionSearchEngine property description indexing', () =>
     expect(matches.map((match) => match.id)).toEqual(['NS:address']);
   });
 });
+
+describe('MiniSearchCollectionSearchEngine keyword indexing', () => {
+  const KEYWORD_COLLECTIONS: Collection[] = [
+    {
+      id: 'NS:wind',
+      namespace: 'NS',
+      name: 'wind',
+      title: 'Wind',
+      description: 'Energy layer',
+      keywords: ['Eolien'],
+      properties: [{ name: 'id', type: 'string' }],
+    },
+    {
+      id: 'NS:solar',
+      namespace: 'NS',
+      name: 'solar',
+      title: 'Solar',
+      description: 'Energy layer with eolien in description',
+      keywords: ['Solaire'],
+      properties: [{ name: 'id', type: 'string' }],
+    },
+  ];
+
+  it('finds a collection by a keyword when no other field matches', () => {
+    const engine = new MiniSearchCollectionSearchEngine(KEYWORD_COLLECTIONS, {
+      defaultSearchOptions: { fuzzy: 0 },
+    });
+
+    const matches = engine.search('solaire');
+
+    expect(matches.map((match) => match.id)).toEqual(['NS:solar']);
+  });
+
+  it('supports searching only in keywords', () => {
+    const engine = new MiniSearchCollectionSearchEngine(KEYWORD_COLLECTIONS, {
+      defaultSearchOptions: { fuzzy: 0 },
+    });
+
+    const matches = engine.search('eolien', { fields: ['keywords'] });
+
+    expect(matches.map((match) => match.id)).toEqual(['NS:wind']);
+  });
+});

--- a/src/search/minisearch-engine.ts
+++ b/src/search/minisearch-engine.ts
@@ -10,6 +10,7 @@ const INDEXED_COLLECTION_FIELDS = [
   'name',
   'title',
   'description',
+  'keywords',
   'properties',
   'enums',
   'identifierTokens',
@@ -27,6 +28,7 @@ export type MiniSearchCollectionSearchOptions = {
     name?: number;
     title?: number;
     description?: number;
+    keywords?: number;
     properties?: number;
     enums?: number;
     identifierTokens?: number;
@@ -54,6 +56,7 @@ const DEFAULT_MINISEARCH_SEARCH_OPTIONS: { boost: ResolvedBoost; fuzzy: number }
     name: 4.0,
     identifierTokens: 3.0,
     title: 2.0,
+    keywords: 1.0,
     description: 1.5,
     properties: 1.3,
     enums: 1.8,
@@ -137,6 +140,9 @@ export class MiniSearchCollectionSearchEngine implements CollectionSearchEngine 
       stringifyField: (fieldValue, fieldName) => {
         if (fieldName === 'properties') {
           return MiniSearchCollectionSearchEngine.stringifyProperties(fieldValue as CollectionProperty[]);
+        }
+        if (fieldName === 'keywords') {
+          return Array.isArray(fieldValue) ? fieldValue.join(' ') : '';
         }
         return String(fieldValue);
       },

--- a/src/services/wfs.integration.test.ts
+++ b/src/services/wfs.integration.test.ts
@@ -13,6 +13,7 @@ const expectedCollections = [
     name: 'collection',
     title: 'Collection title',
     description: 'Collection description',
+    keywords: ['collection'],
   },
 ]
 

--- a/src/services/wfs.test.ts
+++ b/src/services/wfs.test.ts
@@ -7,6 +7,7 @@ import { UnexpectedTypeError } from '../types'
 const endpointMocks = vi.hoisted(() => ({
   isReady: vi.fn(),
   getFeatureTypes: vi.fn(),
+  getFeatureTypeSummary: vi.fn(),
   getFeatureTypeFull: vi.fn(),
   constructor: vi.fn(),
 }))
@@ -19,6 +20,7 @@ vi.mock('@camptocamp/ogc-client', () => {
 
     isReady = endpointMocks.isReady
     getFeatureTypes = endpointMocks.getFeatureTypes
+    getFeatureTypeSummary = endpointMocks.getFeatureTypeSummary
     getFeatureTypeFull = endpointMocks.getFeatureTypeFull
   }
 
@@ -35,9 +37,11 @@ describe('WfsClient', () => {
     endpointMocks.constructor.mockReset()
     endpointMocks.isReady.mockReset()
     endpointMocks.getFeatureTypes.mockReset()
+    endpointMocks.getFeatureTypeSummary.mockReset()
     endpointMocks.getFeatureTypeFull.mockReset()
     endpointMocks.isReady.mockResolvedValue(undefined)
     endpointMocks.getFeatureTypes.mockReturnValue([])
+    endpointMocks.getFeatureTypeSummary.mockReturnValue(null)
   })
 
   afterEach(() => {
@@ -73,6 +77,11 @@ describe('WfsClient', () => {
         { name: 'BDTOPO_V3:batiment', title: 'batiment', abstract: '' },
         { name: 'BDTOPO_V3:commune', title: 'commune', abstract: '' },
       ])
+      endpointMocks.getFeatureTypeSummary.mockImplementation((name: string) => {
+        if (name === 'BDTOPO_V3:batiment') return { keywords: ['features', 'building', 'WFS', 'topography'] }
+        if (name === 'BDTOPO_V3:commune') return { keywords: ['feature', 'municipality'] }
+        return null
+      })
 
       const wfsClient = new WfsClient('https://example.test/wfs')
       const promise = wfsClient.getCollections()
@@ -83,6 +92,7 @@ describe('WfsClient', () => {
           name: 'batiment',
           title: 'batiment',
           description: '',
+          keywords: ['building', 'topography'],
         },
         {
           id: 'BDTOPO_V3:commune',
@@ -90,6 +100,7 @@ describe('WfsClient', () => {
           name: 'commune',
           title: 'commune',
           description: '',
+          keywords: ['municipality'],
         },
       ])
       await vi.runAllTimersAsync()
@@ -99,6 +110,7 @@ describe('WfsClient', () => {
       expect(endpointMocks.constructor).toHaveBeenCalledWith('https://example.test/wfs?_t=1704067200000')
       expect(endpointMocks.isReady).toHaveBeenCalledTimes(1)
       expect(endpointMocks.getFeatureTypes).toHaveBeenCalledTimes(1)
+      expect(endpointMocks.getFeatureTypeSummary).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -114,6 +126,7 @@ describe('WfsClient', () => {
         defaultCrs: 'EPSG:4326',
         title: 'collection title',
         abstract: 'collection description',
+        keywords: ['features', 'transport', 'WFS'],
       })
     })
 
@@ -126,6 +139,7 @@ describe('WfsClient', () => {
         name: 'collection',
         title: 'collection title',
         description: 'collection description',
+        keywords: ['transport'],
         properties: [
           { name: 'prop1', type: 'string' },
           { name: 'prop2', type: 'float' },

--- a/src/services/wfs.ts
+++ b/src/services/wfs.ts
@@ -7,6 +7,7 @@ import { WfsEndpoint } from '@camptocamp/ogc-client';
 import '../helpers/configure-fetch';
 import { retry } from '../helpers/retry';
 import { parseFeatureTypeName } from '../helpers/metadata';
+import { filterCollectionKeywords } from '../helpers/keywords';
 
 /**
  * Add a timestamp cache buster to the WFS URL to avoid caching issues
@@ -106,13 +107,18 @@ export class WfsClient {
     const collections: CollectionBrief[] = [];
     for (const featureType of featureTypes) {
       const { namespace, name } = parseFeatureTypeName(featureType.name);
+      // getFeatureTypes() is the listing API, but its brief type does not
+      // expose keywords. Summary reads the same parsed GetCapabilities object.
+      const rawKeywords = endpoint.getFeatureTypeSummary(featureType.name)?.keywords;
+      const keywords = filterCollectionKeywords(rawKeywords);
       collections.push({
         id: featureType.name,
-        namespace: namespace,
-        name: name,
+        namespace,
+        name,
         title: featureType.title ?? '',
         description: featureType.abstract ?? '',
-      } as CollectionBrief);
+        ...(keywords?.length ? { keywords } : {}),
+      });
     }
     return collections;
   }
@@ -160,6 +166,7 @@ export class WfsClient {
     }
 
     const { namespace, name } = parseFeatureTypeName(collectionId);
+    const keywords = filterCollectionKeywords(featureTypeFull.keywords);
 
     const collection: Collection = {
       id: collectionId,
@@ -167,6 +174,7 @@ export class WfsClient {
       name: name,
       title: featureTypeFull.title ?? '',
       description: featureTypeFull.abstract ?? '',
+      ...(keywords?.length ? { keywords } : {}),
       properties: properties
     };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -157,8 +157,8 @@ export type Collection = {
   id: string;
   /**
    * The namespace of the collection (ex : "BDTOPO_V3").
-   * 
-   * @warning this is not standard in OGC API - Features 
+   *
+   * @warning this is not standard in OGC API - Features
    * (might be renamed to "serie" if they deal with grouping collections by a common theme and version)
    */
   namespace: string;
@@ -174,6 +174,10 @@ export type Collection = {
    * The description of the collection.
    */
   description: string;
+  /**
+   * The keywords of the collection, as extracted from the WFS GetCapabilities.
+   */
+  keywords?: string[];
   /**
    * The properties of the collection.
    */
@@ -197,7 +201,7 @@ export type CollectionPropertyOverwrite = Omit<CollectionProperty, 'type'> & {
 /**
  * The schema of a collection overwrite.
  */
-export type CollectionOverwrite = Omit<Collection, 'properties'> & {
+export type CollectionOverwrite = Omit<Collection, 'properties' | 'keywords'> & {
   /**
    * The properties of the overwrite.
    */


### PR DESCRIPTION
closes #41 

## Summary

- Add WFS collection keyword extraction from `GetCapabilities`
- Filter generic/noisy WFS keywords from application collections
- Add `wfs-keywords` CLI command to inspect public GPF WFS keyword occurrences
- Index collection keywords in MiniSearch
- Preserve WFS-provided keywords through merge while keeping overwrites from overriding them
- Normalize README line endings to LF and document the new CLI command

## Details

- `WfsClient` now reads keywords through `getFeatureTypeSummary()` while keeping `getFeatureTypes()` as the collection listing source.
- Generic keywords such as `feature`, `features`, `WFS`, `demo`, `test`, and similar noisy values are filtered from stored collections.
- The CLI command `wfs-keywords` queries the public GPF WFS directly and prints keyword occurrence counts, with an optional `--filtered` mode.
- MiniSearch now indexes the optional `keywords` field and supports `fields: ['keywords']`.
- `CollectionOverwrite` no longer accepts `keywords`, making the merge contract explicit: keywords come from the WFS source, not overwrite files.

## Validation

- `npm run typecheck`
- `npm test`
- `git diff --check`
