### PR TITLE
Fix tests and add cases for increased retry delay

### DIFF
--- a/test/integration/search/search.integration.test.ts
+++ b/test/integration/search/search.integration.test.ts
@@ -16,7 +16,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url))
 const useCaseSchema = z.object({
   name: z.string().min(1),
   query: z.string().min(1),
-  expected: z.array(z.string().min(1)).min(1),
+  expected: z.array(z.string().min(1)).min(0),
 })
 
 const useCasesSchema = z.array(useCaseSchema).min(1)

--- a/test/integration/search/use-case.yaml
+++ b/test/integration/search/use-case.yaml
@@ -2,13 +2,253 @@
 # Each test case consists of a name, a query string, and an expected list of IDs that should be returned by the search.
 # Order of expected IDs matters, as the search results are expected to be sorted by relevance.
 
-- name: "search_batiment"
+#--------------------------------------------------------------
+# BDTOPO_V3:batiment
+#--------------------------------------------------------------
+
+- name: "search_batiment1"
   query: "batiment"
   expected:
     - BDTOPO_V3:batiment
     - CADASTRALPARCELS.PARCELLAIRE_EXPRESS:batiment
 
+- name: "search_batiment2"
+  query: "bâtiment BD TOPO"
+  expected:
+    - BDTOPO_V3:batiment
+
+- name: "search_batiment3"
+  query: "BDTOPO batiment"
+  expected:
+    - BDTOPO_V3:batiment
+
+- name: "search_batiment4"
+  query: "bâtiment hauteur"
+  expected:
+    - BDTOPO_V3:batiment
+
+- name: "search_batiment5"
+  query: "batiment bdtopo"
+  expected:
+    - BDTOPO_V3:batiment
+
+- name: "search_batiment6"
+  query: "bati topo batiment"
+  expected:
+    - BDTOPO_V3:batiment
+
+#--------------------------------------------------------------
+# BDTOPO_V3:batiment
+#--------------------------------------------------------------
+
+- name: "search_troncon_route1"
+  query: "BDTOPO troncon route"
+  expected:
+    - BDTOPO_V3:troncon_de_route
+
+- name: "search_troncon_route2"
+  query: "route"
+  expected:
+    - BDTOPO_V3:troncon_de_route
+
+
+#--------------------------------------------------------------
+# BDTOPO_V3:zone_d_activite_ou_d_interet
+#--------------------------------------------------------------
 - name: "search_ecole"
   query: "école"
   expected:
     - BDTOPO_V3:zone_d_activite_ou_d_interet
+
+# ligne électrique pylône poste transformation énergie
+# ligne électrique pylône parking aérodrome construction
+- name: "search_ligne_electrique"
+  query: "ligne électrique haute tension pylône"
+  expected:
+    - BDTOPO_V3:ligne_electrique
+
+- name: "search_zone_activite"
+  query: "zone d'activité commerciale industrielle"
+  expected:
+    - BDTOPO_V3:zone_d_activite_ou_d_interet
+
+# parking aire stationnement surface route autoroute
+- name: "search_parking1"
+  query: "parking"
+  expected:
+    - BDTOPO_V3:equipement_de_transport
+
+- name: "search_batiment_commercial1"
+  query: "bâtiment commercial industriel zone d'activité"
+  expected:
+    - BDTOPO_V3:zone_d_activite_ou_d_interet
+
+
+- name: "search_pharmacie2"
+  query: "santé hôpital pharmacie équipements médicaux"
+  expected:
+    - BDTOPO_V3:zone_d_activite_ou_d_interet
+
+
+- name: "search_lieu_dit_patrimoine1"
+  query: "lieu-dit toponyme nom de lieu zone d'intérêt patrimoine"
+  expected:
+    - BDTOPO_V3:zone_d_activite_ou_d_interet
+
+
+#--------------------------------------------------------------
+# BDTOPO_V3:cours_d_eau
+# BDTOPO_V3:troncon_hydrographique
+# BDTOPO_V3:plan_d_eau
+# BDTOPO_V3:surface_hydrographique
+#--------------------------------------------------------------
+
+# TODO : check order
+- name: "search_hydro1"
+  query: "cours d'eau surface hydrographique rivière"
+  expected:
+    - BDTOPO_V3:surface_hydrographique
+    - BDTOPO_V3:cours_d_eau
+
+- name: "search_hydro2"
+  query: "cours d'eau"
+  expected:
+    - BDTOPO_V3:cours_d_eau
+
+- name: "search_hydro3"
+  query: "plan d'eau"
+  expected:
+    - BDTOPO_V3:plan_d_eau
+
+#--------------------------------------------------------------
+# BDTOPO_V3:departement
+#--------------------------------------------------------------
+
+- name: "search_departement1"
+  query: "département"
+  expected:
+    - BDTOPO_V3:departement
+
+# TODO : KO BDTOPO_V3:limite_terre_mer
+# - name: "search_departement2"
+#   query: "département limite administrative"
+#   expected:
+#     - BDTOPO_V3:departement
+
+
+#--------------------------------------------------------------
+# BDTOPO_V3:commune
+#--------------------------------------------------------------
+
+# TODO : allow different order
+# - name: "search_commune1"
+#   query: "BDTOPO commune"
+#   expected:
+#     - BDTOPO_V3:commune_associee_ou_deleguee
+#     - BDTOPO_V3:commune
+
+
+
+#--------------------------------------------------------------
+# religieux :
+# BDTOPO_V3:batiment
+# BDTOPO_V3:zone_d_activite_ou_d_interet
+#--------------------------------------------------------------
+
+- name: "search_religieux1"
+  query: "édifice religieux abbaye monastère"
+  expected:
+    - BDTOPO_V3:zone_d_activite_ou_d_interet
+
+- name: "search_religieux2"
+  query: "abbaye monastère édifice religieux bâtiment remarquable"
+  expected:
+    - BDTOPO_V3:batiment
+
+- name: "search_religieux3"
+  query: "église lieu de culte"
+  expected:
+    - BDTOPO_V3:zone_d_activite_ou_d_interet
+
+- name: "search_religieux3"
+  query: "bâtiment religieux BDTOPO"
+  expected:
+    - BDTOPO_V3:batiment
+
+# église lieu de culte religieux
+# construction religieuse église abbaye
+# abbaye édifice religieux monument
+# abbaye monument religieux
+
+#--------------------------------------------------------------
+# BDTOPO_V3:zone_de_vegetation
+#--------------------------------------------------------------
+
+# végétation
+- name: "search_vegetation1"
+  query: "végétation"
+  expected:
+    - BDTOPO_V3:zone_de_vegetation
+
+# haie
+- name: "search_haie1"
+  query: "haie"
+  expected:
+    - BDTOPO_V3:haie
+
+# TODO : KO (BDTOPO_V3:lieu_dit_non_habite instead)
+# - name: "search_arbre1"
+#   query: "arbre isole"
+#   expected:
+#     - BDTOPO_V3:zone_de_vegetation
+
+# TODO : KO ( BDTOPO_V3:lieu_dit_non_habite )
+# - name: "search_arbre2"
+#   query: "arbre"
+#   expected:
+#     - BDTOPO_V3:zone_de_vegetation
+
+
+#--------------------------------------------------------------
+# NO DATA -> no results
+#--------------------------------------------------------------
+
+# no data in BDTOPO
+- name: "search_pharmacie1"
+  query: "pharmacie officine"
+  expected: []
+
+# ORTHOIMAGERY.* disabled for now
+- name: "search_orthophoto1"
+  query: "orthophoto"
+  expected: []
+
+# ORTHOIMAGERY.* disabled for now
+- name: "search_orthophoto2"
+  query: "orthophoto raster"
+  expected: []
+
+# no data?
+- name: "search_geologie1"
+  query: "argile sol géologie"
+  expected: []
+
+# could find some SUP?
+- name: "search_geologie2"
+  query: "retrait gonflement argiles aléa"
+  expected: []
+
+# no data ? BDIFF not published on GPF ?
+- name: "search_incendie1"
+  query: "incendie forêt zonage feux DFCI"
+  expected: []
+
+# DEBROUSSAILLEMENT disabled for now
+- name: "search_debroussaillement1"
+  query: "obligations légales débroussaillement OLD"
+  expected: []
+
+
+
+
+

--- a/test/unit/source/wfs.test.ts
+++ b/test/unit/source/wfs.test.ts
@@ -69,7 +69,7 @@ describe('WfsClient', () => {
       expect(endpointMocks.constructor).toHaveBeenCalledTimes(2)
       expect(endpointMocks.constructor.mock.calls.map(([url]) => url)).toEqual([
         'https://example.test/wfs?_t=1704067200000',
-        'https://example.test/wfs?_t=1704067201000',
+        'https://example.test/wfs?_t=1704067202000',
       ])
       expect(endpointMocks.isReady).toHaveBeenCalledTimes(2)
     })


### PR DESCRIPTION
This pull request expands the integration test coverage for the search functionality by adding a large number of new test cases to `use-case.yaml`, covering various search queries and their expected results. It also makes a minor schema change to allow test cases with empty expected results and updates a unit test to match a new expected URL.

**Test Coverage Improvements:**

* Added numerous new search test cases in `test/integration/search/use-case.yaml`, covering a wide range of queries and expected results, including cases for buildings, roads, hydrography, administrative areas, vegetation, and cases where no data should be found. This significantly improves the comprehensiveness of the integration tests (refs #49)

**Test Schema and Test Logic Adjustments:**

* Updated the `useCaseSchema` in `test/integration/search/search.integration.test.ts` to allow test cases where the list of expected results is empty, enabling negative test cases.

**Unit Test Correction:**

* Adjusted the expected URL in the `WfsClient` unit test to account for a new timestamp value, ensuring the test matches the updated logic.