### PR TITLE
chore(catalog): rename getById to getCollectionSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ console.log("collections:", collections.length);
 
 ```ts
 // Note : "batiment" = "buildings" in french
-const bdtopoBatiment = catalog.getById("BDTOPO_V3:batiment");
+const bdtopoBatiment = catalog.getCollectionSchema("BDTOPO_V3:batiment");
 console.log(`BDTOPO_V3:batiment schema : ${JSON.stringify(bdtopoBatiment,null,2)}`);
 ```
 

--- a/src/catalog/in-memory.ts
+++ b/src/catalog/in-memory.ts
@@ -37,7 +37,7 @@ export class InMemoryCollectionCatalog implements CollectionCatalog {
     return this.briefs.map((brief) => structuredClone(brief));
   }
 
-  getById(id: string): OgcCollectionSchema | undefined {
+  getCollectionSchema(id: string): OgcCollectionSchema | undefined {
     const schema = this.schemasById.get(id);
     return schema ? structuredClone(schema) : undefined;
   }

--- a/src/catalog/types.ts
+++ b/src/catalog/types.ts
@@ -20,7 +20,7 @@ export interface CollectionCatalog {
    * 
    * Expected as "GET /collections/{id}/schema"
    */
-  getById(id: string): OgcCollectionSchema | undefined;
+  getCollectionSchema(id: string): OgcCollectionSchema | undefined;
 
   /**
    * Search collection by keyword

--- a/test/unit/catalog/in-memory.test.ts
+++ b/test/unit/catalog/in-memory.test.ts
@@ -85,7 +85,7 @@ describe('InMemoryCollectionCatalog', () => {
 
   describe('getCollectionSchema', () => {
 
-    it("returns null if the type doesn't exists", () => {
+    it("returns undefined if the type doesn't exist", () => {
       const catalog = new InMemoryCollectionCatalog(FIXTURES, new NullSearchEngine());
       const collection = catalog.getCollectionSchema('NS:not_found');
       expect(collection).toBeUndefined();

--- a/test/unit/catalog/in-memory.test.ts
+++ b/test/unit/catalog/in-memory.test.ts
@@ -83,25 +83,25 @@ describe('InMemoryCollectionCatalog', () => {
   });
 
 
-  describe('getById', () => {
+  describe('getCollectionSchema', () => {
 
     it("returns null if the type doesn't exists", () => {
       const catalog = new InMemoryCollectionCatalog(FIXTURES, new NullSearchEngine());
-      const collection = catalog.getById('NS:not_found');
+      const collection = catalog.getCollectionSchema('NS:not_found');
       expect(collection).toBeUndefined();
     });
 
-    it('returns cloned values from getById', () => {
+    it('returns cloned values from getCollectionSchema', () => {
       const catalog = new InMemoryCollectionCatalog(FIXTURES, new NullSearchEngine());
 
-      const first = catalog.getById('NS:first');
+      const first = catalog.getCollectionSchema('NS:first');
       expect(first).toBeDefined();
       if (!first) {
         return;
       }
       first.title = 'Mutated again';
 
-      const firstAgain = catalog.getById('NS:first');
+      const firstAgain = catalog.getCollectionSchema('NS:first');
       expect(firstAgain?.title).toBe('First');
     });
 

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -44,7 +44,7 @@ describe('getCollectionCatalog', () => {
       const searchEngine = new SingleMatchEngine('BDTOPO_V3:batiment');
       const catalog = getCollectionCatalog({ searchEngine });
 
-      expect(catalog.getById('BDTOPO_V3:batiment')).toBeDefined();
+      expect(catalog.getCollectionSchema('BDTOPO_V3:batiment')).toBeDefined();
 
       const ids = catalog.search('bâtiments bdtopo', {
         limit: 10,


### PR DESCRIPTION
This pull request refactors the `CollectionCatalog` interface and related classes to rename the method `getById` to `getCollectionSchema`. This change improves clarity by making the method's purpose more explicit. The update is applied consistently across the implementation, interface, tests, and documentation.

**API Naming Improvements:**

* Renamed the `getById` method to `getCollectionSchema` in the `CollectionCatalog` interface (`src/catalog/types.ts`) and its implementation in `InMemoryCollectionCatalog` (`src/catalog/in-memory.ts`). [[1]](diffhunk://#diff-6a46dd55c66996c4239e856cb9f0cbfdeb57aac7962ef42fc61a96b9c822c8f3L23-R23) [[2]](diffhunk://#diff-eaeaa883a81ce46b8ab236853027e3ccd505b9db0984d2ad2e3c0cdaa82a4fbeL40-R40)
* Updated all usages of `getById` to `getCollectionSchema` in tests (`test/unit/catalog/in-memory.test.ts`, `test/unit/index.test.ts`) and documentation (`README.md`).

(closes #68 )