### PR TITLE
Translate WFS date and date-time types for OGC API Feature schema

### DIFF
--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/commune.json
@@ -25,7 +25,8 @@
       "type": "integer"
     },
     "date_du_recensement": {
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "organisme_recenseur": {
       "type": "string"

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/commune.json
@@ -25,7 +25,8 @@
       "type": "integer"
     },
     "date_du_recensement": {
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "organisme_recenseur": {
       "type": "string"

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/commune.json
@@ -25,7 +25,8 @@
       "type": "integer"
     },
     "date_du_recensement": {
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "organisme_recenseur": {
       "type": "string"

--- a/data/catalog/ADMINEXPRESS-COG.2025/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/commune.json
@@ -25,7 +25,8 @@
       "type": "integer"
     },
     "date_du_recensement": {
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "organisme_recenseur": {
       "type": "string"

--- a/data/catalog/ADMINEXPRESS-COG.2026/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/commune.json
@@ -25,7 +25,8 @@
       "type": "integer"
     },
     "date_du_recensement": {
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "organisme_recenseur": {
       "type": "string"

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/commune.json
@@ -25,7 +25,8 @@
       "type": "integer"
     },
     "date_du_recensement": {
-      "type": "string"
+      "type": "string",
+      "format": "date"
     },
     "organisme_recenseur": {
       "type": "string"

--- a/data/catalog/BDTOPO_V3/aerodrome.json
+++ b/data/catalog/BDTOPO_V3/aerodrome.json
@@ -185,21 +185,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/arrondissement.json
+++ b/data/catalog/BDTOPO_V3/arrondissement.json
@@ -44,21 +44,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/arrondissement_municipal.json
+++ b/data/catalog/BDTOPO_V3/arrondissement_municipal.json
@@ -34,21 +34,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/bassin_versant_topographique.json
+++ b/data/catalog/BDTOPO_V3/bassin_versant_topographique.json
@@ -289,21 +289,25 @@
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },

--- a/data/catalog/BDTOPO_V3/batiment.json
+++ b/data/catalog/BDTOPO_V3/batiment.json
@@ -361,21 +361,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/canalisation.json
+++ b/data/catalog/BDTOPO_V3/canalisation.json
@@ -76,21 +76,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/cimetiere.json
+++ b/data/catalog/BDTOPO_V3/cimetiere.json
@@ -253,21 +253,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/collectivite_territoriale.json
+++ b/data/catalog/BDTOPO_V3/collectivite_territoriale.json
@@ -34,21 +34,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/commune.json
+++ b/data/catalog/BDTOPO_V3/commune.json
@@ -55,21 +55,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },
@@ -110,6 +114,7 @@
     },
     "date_du_recensement": {
       "type": "string",
+      "format": "date",
       "title": "Date du recensement",
       "description": "Date du recensement correspondant au chiffre de population saisi dans le champ 'Population'."
     },

--- a/data/catalog/BDTOPO_V3/commune_associee_ou_deleguee.json
+++ b/data/catalog/BDTOPO_V3/commune_associee_ou_deleguee.json
@@ -55,21 +55,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/condominium.json
+++ b/data/catalog/BDTOPO_V3/condominium.json
@@ -19,21 +19,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/construction_lineaire.json
+++ b/data/catalog/BDTOPO_V3/construction_lineaire.json
@@ -428,21 +428,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/construction_ponctuelle.json
+++ b/data/catalog/BDTOPO_V3/construction_ponctuelle.json
@@ -293,21 +293,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/construction_surfacique.json
+++ b/data/catalog/BDTOPO_V3/construction_surfacique.json
@@ -205,21 +205,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/cours_d_eau.json
+++ b/data/catalog/BDTOPO_V3/cours_d_eau.json
@@ -95,21 +95,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/departement.json
+++ b/data/catalog/BDTOPO_V3/departement.json
@@ -34,21 +34,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/detail_hydrographique.json
+++ b/data/catalog/BDTOPO_V3/detail_hydrographique.json
@@ -333,21 +333,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/detail_orographique.json
+++ b/data/catalog/BDTOPO_V3/detail_orographique.json
@@ -324,21 +324,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/epci.json
+++ b/data/catalog/BDTOPO_V3/epci.json
@@ -57,21 +57,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/equipement_de_transport.json
+++ b/data/catalog/BDTOPO_V3/equipement_de_transport.json
@@ -528,21 +528,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/foret_publique.json
+++ b/data/catalog/BDTOPO_V3/foret_publique.json
@@ -105,21 +105,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/haie.json
+++ b/data/catalog/BDTOPO_V3/haie.json
@@ -14,21 +14,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/itineraire_autre.json
+++ b/data/catalog/BDTOPO_V3/itineraire_autre.json
@@ -127,21 +127,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/lieu_dit_non_habite.json
+++ b/data/catalog/BDTOPO_V3/lieu_dit_non_habite.json
@@ -129,21 +129,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/ligne_electrique.json
+++ b/data/catalog/BDTOPO_V3/ligne_electrique.json
@@ -94,21 +94,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/ligne_orographique.json
+++ b/data/catalog/BDTOPO_V3/ligne_orographique.json
@@ -78,21 +78,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/limite_terre_mer.json
+++ b/data/catalog/BDTOPO_V3/limite_terre_mer.json
@@ -79,21 +79,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/noeud_hydrographique.json
+++ b/data/catalog/BDTOPO_V3/noeud_hydrographique.json
@@ -102,21 +102,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/non_communication.json
+++ b/data/catalog/BDTOPO_V3/non_communication.json
@@ -15,21 +15,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/parc_ou_reserve.json
+++ b/data/catalog/BDTOPO_V3/parc_ou_reserve.json
@@ -303,21 +303,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/piste_d_aerodrome.json
+++ b/data/catalog/BDTOPO_V3/piste_d_aerodrome.json
@@ -99,21 +99,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/plan_d_eau.json
+++ b/data/catalog/BDTOPO_V3/plan_d_eau.json
@@ -268,21 +268,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/point_d_acces.json
+++ b/data/catalog/BDTOPO_V3/point_d_acces.json
@@ -14,21 +14,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/point_de_repere.json
+++ b/data/catalog/BDTOPO_V3/point_de_repere.json
@@ -18,21 +18,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/point_du_reseau.json
+++ b/data/catalog/BDTOPO_V3/point_du_reseau.json
@@ -148,21 +148,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/poste_de_transformation.json
+++ b/data/catalog/BDTOPO_V3/poste_de_transformation.json
@@ -115,21 +115,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/pylone.json
+++ b/data/catalog/BDTOPO_V3/pylone.json
@@ -47,21 +47,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/region.json
+++ b/data/catalog/BDTOPO_V3/region.json
@@ -29,21 +29,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/reservoir.json
+++ b/data/catalog/BDTOPO_V3/reservoir.json
@@ -85,21 +85,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/route_numerotee_ou_nommee.json
+++ b/data/catalog/BDTOPO_V3/route_numerotee_ou_nommee.json
@@ -136,21 +136,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/section_de_points_de_repere.json
+++ b/data/catalog/BDTOPO_V3/section_de_points_de_repere.json
@@ -63,16 +63,19 @@
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },

--- a/data/catalog/BDTOPO_V3/surface_hydrographique.json
+++ b/data/catalog/BDTOPO_V3/surface_hydrographique.json
@@ -274,21 +274,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/terrain_de_sport.json
+++ b/data/catalog/BDTOPO_V3/terrain_de_sport.json
@@ -195,21 +195,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/toponymie.json
+++ b/data/catalog/BDTOPO_V3/toponymie.json
@@ -65,6 +65,7 @@
     },
     "date_du_toponyme": {
       "type": "string",
+      "format": "date",
       "title": "Date du toponyme",
       "description": "Date de saisie ou de validation de la graphie."
     },

--- a/data/catalog/BDTOPO_V3/transport_par_cable.json
+++ b/data/catalog/BDTOPO_V3/transport_par_cable.json
@@ -178,21 +178,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/troncon_de_route.json
+++ b/data/catalog/BDTOPO_V3/troncon_de_route.json
@@ -241,21 +241,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },
@@ -861,6 +865,7 @@
     },
     "date_de_mise_en_service": {
       "type": "string",
+      "format": "date",
       "title": "Date de mise en service",
       "description": "Indique la date prévisionnelle ou effective de mise en service des tronçons de route dont l’attribut commun 'Etat de l’objet' prend la valeur \"En construction\". Ce champ est vide pour les tronçons de route dont le champ 'Etat de l’objet' prend la valeur \"En service\"."
     },

--- a/data/catalog/BDTOPO_V3/troncon_de_voie_ferree.json
+++ b/data/catalog/BDTOPO_V3/troncon_de_voie_ferree.json
@@ -160,21 +160,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/troncon_hydrographique.json
+++ b/data/catalog/BDTOPO_V3/troncon_hydrographique.json
@@ -262,21 +262,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/voie_ferree_nommee.json
+++ b/data/catalog/BDTOPO_V3/voie_ferree_nommee.json
@@ -52,21 +52,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/voie_nommee.json
+++ b/data/catalog/BDTOPO_V3/voie_nommee.json
@@ -74,11 +74,13 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },

--- a/data/catalog/BDTOPO_V3/zone_d_activite_ou_d_interet.json
+++ b/data/catalog/BDTOPO_V3/zone_d_activite_ou_d_interet.json
@@ -3523,21 +3523,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/zone_d_estran.json
+++ b/data/catalog/BDTOPO_V3/zone_d_estran.json
@@ -47,21 +47,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/zone_d_habitation.json
+++ b/data/catalog/BDTOPO_V3/zone_d_habitation.json
@@ -286,21 +286,25 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },

--- a/data/catalog/BDTOPO_V3/zone_de_vegetation.json
+++ b/data/catalog/BDTOPO_V3/zone_de_vegetation.json
@@ -14,11 +14,13 @@
     },
     "date_d_apparition": {
       "type": "string",
+      "format": "date",
       "title": "Date d'apparition",
       "description": "Date de création, de construction ou d'apparition de l'objet, ou date la plus ancienne à laquelle on peut attester de sa présence sur le terrain."
     },
     "date_de_confirmation": {
       "type": "string",
+      "format": "date",
       "title": "Date de confirmation",
       "description": "Date la plus récente à laquelle on peut attester de la présence de l'objet sur le terrain ou par des données externes de référence."
     },
@@ -336,11 +338,13 @@
     },
     "date_creation": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de création",
       "description": "Date et heure à laquelle l'objet a été saisi pour la première fois dans la base de données de production de l'IGN."
     },
     "date_modification": {
       "type": "string",
+      "format": "date-time",
       "title": "Date de modification",
       "description": "Date et heure à laquelle l'objet a été modifié pour la dernière fois dans la base de données de production."
     },

--- a/data/catalog/wfs_du/doc_urba.json
+++ b/data/catalog/wfs_du/doc_urba.json
@@ -70,7 +70,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_du/doc_urba.json
+++ b/data/catalog/wfs_du/doc_urba.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"
@@ -72,6 +73,12 @@
       "format": "geometry-geometry",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
+    },
+    "nomrapp": {
+      "type": "string"
+    },
+    "urlrapp": {
+      "type": "string"
     }
   },
   "required": []

--- a/data/catalog/wfs_du/doc_urba_com.json
+++ b/data/catalog/wfs_du/doc_urba_com.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_du/doc_urba_com.json
+++ b/data/catalog/wfs_du/doc_urba_com.json
@@ -31,7 +31,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     }

--- a/data/catalog/wfs_du/document.json
+++ b/data/catalog/wfs_du/document.json
@@ -37,7 +37,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     }

--- a/data/catalog/wfs_du/document.json
+++ b/data/catalog/wfs_du/document.json
@@ -27,7 +27,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_du/habillage_lin.json
+++ b/data/catalog/wfs_du/habillage_lin.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_du/habillage_lin.json
+++ b/data/catalog/wfs_du/habillage_lin.json
@@ -40,7 +40,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     }

--- a/data/catalog/wfs_du/habillage_pct.json
+++ b/data/catalog/wfs_du/habillage_pct.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_du/habillage_pct.json
+++ b/data/catalog/wfs_du/habillage_pct.json
@@ -40,7 +40,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     }

--- a/data/catalog/wfs_du/habillage_surf.json
+++ b/data/catalog/wfs_du/habillage_surf.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_du/habillage_surf.json
+++ b/data/catalog/wfs_du/habillage_surf.json
@@ -40,7 +40,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     }

--- a/data/catalog/wfs_du/habillage_txt.json
+++ b/data/catalog/wfs_du/habillage_txt.json
@@ -55,7 +55,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     }

--- a/data/catalog/wfs_du/habillage_txt.json
+++ b/data/catalog/wfs_du/habillage_txt.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_du/info_lin.json
+++ b/data/catalog/wfs_du/info_lin.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_du/info_lin.json
+++ b/data/catalog/wfs_du/info_lin.json
@@ -61,7 +61,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_du/info_pct.json
+++ b/data/catalog/wfs_du/info_pct.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_du/info_pct.json
+++ b/data/catalog/wfs_du/info_pct.json
@@ -61,7 +61,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_du/info_surf.json
+++ b/data/catalog/wfs_du/info_surf.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_du/info_surf.json
+++ b/data/catalog/wfs_du/info_surf.json
@@ -61,7 +61,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_du/mec.json
+++ b/data/catalog/wfs_du/mec.json
@@ -30,7 +30,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "gpu_doc_id": {
       "type": "string"

--- a/data/catalog/wfs_du/mec.json
+++ b/data/catalog/wfs_du/mec.json
@@ -40,7 +40,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     }

--- a/data/catalog/wfs_du/municipality.json
+++ b/data/catalog/wfs_du/municipality.json
@@ -18,7 +18,7 @@
       "type": "boolean"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_du/prescription_lin.json
+++ b/data/catalog/wfs_du/prescription_lin.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_du/prescription_lin.json
+++ b/data/catalog/wfs_du/prescription_lin.json
@@ -58,7 +58,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_du/prescription_pct.json
+++ b/data/catalog/wfs_du/prescription_pct.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_du/prescription_pct.json
+++ b/data/catalog/wfs_du/prescription_pct.json
@@ -61,7 +61,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_du/prescription_surf.json
+++ b/data/catalog/wfs_du/prescription_surf.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_du/prescription_surf.json
+++ b/data/catalog/wfs_du/prescription_surf.json
@@ -58,7 +58,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_du/secteur_cc.json
+++ b/data/catalog/wfs_du/secteur_cc.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_du/secteur_cc.json
+++ b/data/catalog/wfs_du/secteur_cc.json
@@ -58,7 +58,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_du/zone_urba.json
+++ b/data/catalog/wfs_du/zone_urba.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_du/zone_urba.json
+++ b/data/catalog/wfs_du/zone_urba.json
@@ -58,7 +58,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_scot/doc_urba.json
+++ b/data/catalog/wfs_scot/doc_urba.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_scot/doc_urba_com.json
+++ b/data/catalog/wfs_scot/doc_urba_com.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_scot/perimetre_scot.json
+++ b/data/catalog/wfs_scot/perimetre_scot.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_scot/perimetre_scot.json
+++ b/data/catalog/wfs_scot/perimetre_scot.json
@@ -25,7 +25,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     }

--- a/data/catalog/wfs_scot/scot.json
+++ b/data/catalog/wfs_scot/scot.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_scot/scot.json
+++ b/data/catalog/wfs_scot/scot.json
@@ -34,7 +34,7 @@
       "type": "boolean"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     }

--- a/data/catalog/wfs_sup/acte_sup.json
+++ b/data/catalog/wfs_sup/acte_sup.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_sup/acte_sup.json
+++ b/data/catalog/wfs_sup/acte_sup.json
@@ -49,7 +49,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     }

--- a/data/catalog/wfs_sup/assiette_sup_l.json
+++ b/data/catalog/wfs_sup/assiette_sup_l.json
@@ -61,7 +61,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_sup/assiette_sup_l.json
+++ b/data/catalog/wfs_sup/assiette_sup_l.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "suptype": {
       "type": "string"

--- a/data/catalog/wfs_sup/assiette_sup_p.json
+++ b/data/catalog/wfs_sup/assiette_sup_p.json
@@ -61,7 +61,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_sup/assiette_sup_p.json
+++ b/data/catalog/wfs_sup/assiette_sup_p.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "suptype": {
       "type": "string"

--- a/data/catalog/wfs_sup/assiette_sup_s.json
+++ b/data/catalog/wfs_sup/assiette_sup_s.json
@@ -85,7 +85,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_sup/assiette_sup_s.json
+++ b/data/catalog/wfs_sup/assiette_sup_s.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "suptype": {
       "type": "string"

--- a/data/catalog/wfs_sup/generateur_sup_l.json
+++ b/data/catalog/wfs_sup/generateur_sup_l.json
@@ -79,7 +79,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_sup/generateur_sup_l.json
+++ b/data/catalog/wfs_sup/generateur_sup_l.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "suptype": {
       "type": "string"

--- a/data/catalog/wfs_sup/generateur_sup_p.json
+++ b/data/catalog/wfs_sup/generateur_sup_p.json
@@ -67,7 +67,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_sup/generateur_sup_p.json
+++ b/data/catalog/wfs_sup/generateur_sup_p.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "suptype": {
       "type": "string"

--- a/data/catalog/wfs_sup/generateur_sup_s.json
+++ b/data/catalog/wfs_sup/generateur_sup_s.json
@@ -85,7 +85,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_sup/generateur_sup_s.json
+++ b/data/catalog/wfs_sup/generateur_sup_s.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "suptype": {
       "type": "string"

--- a/data/catalog/wfs_sup/gestionnaire_sup.json
+++ b/data/catalog/wfs_sup/gestionnaire_sup.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_sup/gestionnaire_sup.json
+++ b/data/catalog/wfs_sup/gestionnaire_sup.json
@@ -40,7 +40,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     }

--- a/data/catalog/wfs_sup/servitude.json
+++ b/data/catalog/wfs_sup/servitude.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_sup/servitude.json
+++ b/data/catalog/wfs_sup/servitude.json
@@ -67,7 +67,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     },

--- a/data/catalog/wfs_sup/servitude_acte_sup.json
+++ b/data/catalog/wfs_sup/servitude_acte_sup.json
@@ -15,7 +15,8 @@
       "type": "string"
     },
     "gpu_timestamp": {
-      "type": "string"
+      "type": "string",
+      "format": "date-time"
     },
     "partition": {
       "type": "string"

--- a/data/catalog/wfs_sup/servitude_acte_sup.json
+++ b/data/catalog/wfs_sup/servitude_acte_sup.json
@@ -28,7 +28,7 @@
       "type": "string"
     },
     "the_geom": {
-      "format": "geometry-geometry",
+      "format": "geometry-any",
       "x-ogc-role": "primary-geometry",
       "x-ign-defaultCrs": "EPSG:4326"
     }

--- a/data/namespaces.csv
+++ b/data/namespaces.csv
@@ -184,11 +184,9 @@ VIGICRUES_TRONCONS_BDD_WLD_WM_2023-v1,,true,Waiting for MCP use case definition,
 VIGINOND-DIFFUSION,,true,Waiting for MCP use case definition,"stationhydro|zich|zip"
 ZONES-A-PROSPECTER-FORETS-SUBNATURELLES,,true,Waiting for MCP use case definition,zones_a_prospecter_forets_subnaturelles
 ZZZ_INAO_LaCiotat,,true,Test data,"batiment|commune|point_du_reseau|troncon_de_route"
+_fff5e2a8-285f-4d47-966a-05784aa29b34_wfs,,true,No matching rule,geometry1
 aeag-rwbody-sdage2022,,true,Test data,rwbody_ag_sdage2022
-batiment_tp100_gpkg_wfs,,true,Test data,batiment_tp100
-carr_10km_gpkg_24-10-2024_wfs,,true,Test data,carr_10km
-carr_1km_zip_24-10-2024_wfs,,true,Test data,carr_1km
-carr_200m_zip_24-10-2024_wfs,,true,Test data,carr_200m
+arbre_wfs,,true,No matching rule,arbre
 cartes,,true,Image index dataset,"dataset|image"
 cartes_anciennes,,true,Image index dataset,"dataset|image"
 cavp_zae_zip_03-02-2026_wfs,,true,Test data,ZAE_CA_Val_Parisis
@@ -196,7 +194,7 @@ charbo_gpkg_30-10-2025_wfs,,true,Test data,"detections_charbonnieres|detections_
 commune_d34OPenIG_gpkg_26-03-2025_wfs,,true,Test data,commune_d034_20170303zip
 communes_972,,true,Test data,commune972
 cosia_032_aubiet,,true,Test data,data_aubiet_25_05
-datac_acid_stats,unknown,true,Fail to assign to an existing product,"datac_acid_objets|datac_acid_stats"
+datac_suivi_acid,,true,No matching rule,"acids_objets|acids_stats"
 dgac_peb_arrete_wfs,,true,Test data,dgac_peb_arrete_wfs
 dgac_psa_arrete_wfs,,true,Test data,dgac_psa_arrete
 ecoregions,ecoregions,true,Waiting for MCP use case definition,"pays|regions_ecologiques"
@@ -206,7 +204,6 @@ etude_25145_15-07-2026_wfs,,true,Test data,geometrie_ucs
 example_gpkg_21-05-2026_wfs,,true,Test data,"geometry1|geometry2|line1"
 fr_qa_stations,unknown,true,Fail to assign to an existing product,stations_qualite_air
 igngpf_4902_20260309_tables_sans_tirets,,true,Test data,parcs_photovoltaiques
-itineraire_randonnee_bm_telethon_gpkg_gpkg_21-01-2026_wfs,,true,Test data,itineraire_randonnee_bm_telethon
 jpe_test_open_io,,true,Test data,formation_vegetale
 l_dfci_zonage_s_088_2025_zip_12-05-2026_wfs,,true,Test data,l_dfci_zonage_s_088_2025
 l_rgc_l_008_20-02-2026_wfs,,true,Test data,l_rgc_l_008
@@ -225,8 +222,8 @@ paec_bfc_2026,,true,Test data,Territoires_paec_bfc_2026
 pat_r84_nov2025_gpkg_2026-02-10_wfs,,true,Test data,sql_statement
 patrinat_apb,PATRINAT,true,Waiting for MCP use case definition,apb
 patrinat_apg,PATRINAT,true,Waiting for MCP use case definition,apg
-patrinat_aphn,PATRINAT,true,Waiting for MCP use case definition,aire_protection_habitats_naturels
-patrinat_aplg,PATRINAT,true,Waiting for MCP use case definition,apg
+patrinat_aphn,PATRINAT,true,Waiting for MCP use case definition,aphn
+patrinat_aplg,PATRINAT,true,Waiting for MCP use case definition,aplg
 patrinat_bios,PATRINAT,true,Waiting for MCP use case definition,bios
 patrinat_bpm,PATRINAT,true,Waiting for MCP use case definition,Bien_patrimoine_mondial_UNESCO
 patrinat_cdl,PATRINAT,true,Waiting for MCP use case definition,conservatoire_littoral
@@ -241,8 +238,9 @@ patrinat_pn2,PATRINAT,true,Waiting for MCP use case definition,pn
 patrinat_pnm,PATRINAT,true,Waiting for MCP use case definition,pnm
 patrinat_pnr,PATRINAT,true,Waiting for MCP use case definition,pnr
 patrinat_pprnn,PATRINAT,true,Waiting for MCP use case definition,pprnn
-patrinat_ramsar,PATRINAT,true,Waiting for MCP use case definition,pnm
-patrinat_rb,PATRINAT,true,Waiting for MCP use case definition,reserve_biologique
+patrinat_pprnr,PATRINAT,true,Waiting for MCP use case definition,pprnr
+patrinat_ramsar,PATRINAT,true,Waiting for MCP use case definition,ramsar
+patrinat_rb,PATRINAT,true,Waiting for MCP use case definition,rb
 patrinat_ripn,PATRINAT,true,Waiting for MCP use case definition,ripn
 patrinat_rnc,PATRINAT,true,Waiting for MCP use case definition,pnm
 patrinat_rncfs,PATRINAT,true,Waiting for MCP use case definition,rncfs
@@ -259,13 +257,13 @@ patrinat_zps,PATRINAT,true,Waiting for MCP use case definition,zps
 pays_ecoregions,pays_ecoregions,true,Duplicate dataset (ecoregions),"pays|regions_ecologiques"
 pnrvn_gpkg_27-06-2025_wfs,,true,Test data,pnrvn
 potentiel_agronomique_CCC,,true,Waiting for MCP use case definition,potentiel agronomique
+ppri-agglo-laval-revision_gpkg_13-10-2025_wfs,,true,No matching rule,n_zone_reg_pprn_202000001_s_053
 projet_amenagement_gosb_cnig,,true,Test data,projet_amenagement_cnig_gosb_16_07_2026
 projet_iqp_2025_gpkg_12-03-2026_wfs,,true,Test data,"tampon_iqp_d_2025|tampon_iqp_g_2025|tampon_iqp_i_2025|ref_interplo_2025|ref_bornage_2025"
 projets_zones_acceleration_energies_renouvelables_zaer_wfs,,true,Test data,fus_epci_ddt_portail_publication
 pva,,true,Image index dataset,"dataset|image"
 quartierscholet,,true,Test data,QuartierCholet
 ramsar-wfs,,true,Test data,ramsar
-rlpi_projet_gpkg_18-12-2025_wfs,,true,Test data,capv_zonage_rpli
 route500logoqgis,,true,Test data,route500logoqgis
 rpg_metrolyon_epsg2154_gpkg_02-04-2026_wfs,,true,Test data,parcelles_graphiques
 sentiers_pag_gpkg_30-01-2026_wfs,,true,Test data,sentiers_PAG
@@ -279,6 +277,7 @@ test_lc_bdtopo_laCiotat,,true,Test data,"batiment|lc_test_commune|point_du_resea
 test_mig_rlt,,true,Test data,"dataset|image"
 test_nl_bdtopo_la_ciotat,,true,Test data,"nl_test_batiment|nl_test_commune|nl_test_point_du_reseau|nl_test_troncon_de_route"
 test_nl_ifn_stats_2024,,true,Test data,stats_2024
+test_retour_ACID_Marin,,true,Test data,test_retour_ACID_Marin
 test_thomas_2,,true,Test data,"troncon_de_route|non communication"
 trichls_s_d51_gpkg_07-10-2024_wfs,,true,Test data,trichls_s_d51
 trichlscomm_s_d51_gpkg_07-10-2024_wfs,,true,Test data,trichlscomm_s_d51
@@ -301,4 +300,5 @@ zzz_test_LC_atelier_maj_donnees_vecteur,,true,Test data,table_a_modif
 zzz_test_NL_atelier_donnees_derivee_vecteur,,true,Test data,table_a_modif
 zzz_test_NL_atelier_maj_donnees_vecteur,,true,Test data,table_a_modif
 zzz_test_RM_atelier_maj_donnees_vecteur,,true,Test data,table_a_modif
+zzz_test_nl_la_ciotat,,true,Test data,"lct_bati|troncon_de_route"
 zzz_test_nl_pn,,true,Test data,parc_national

--- a/data/wfs/ADMINEXPRESS-COG-CARTO-PE.2025/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG-CARTO-PE.2025/commune.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "date_du_recensement",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "organisme_recenseur",

--- a/data/wfs/ADMINEXPRESS-COG-CARTO-PE.2026/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG-CARTO-PE.2026/commune.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "date_du_recensement",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "organisme_recenseur",

--- a/data/wfs/ADMINEXPRESS-COG-CARTO-PE.LATEST/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG-CARTO-PE.LATEST/commune.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "date_du_recensement",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "organisme_recenseur",

--- a/data/wfs/ADMINEXPRESS-COG.2025/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2025/commune.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "date_du_recensement",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "organisme_recenseur",

--- a/data/wfs/ADMINEXPRESS-COG.2026/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.2026/commune.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "date_du_recensement",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "organisme_recenseur",

--- a/data/wfs/ADMINEXPRESS-COG.LATEST/commune.json
+++ b/data/wfs/ADMINEXPRESS-COG.LATEST/commune.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "date_du_recensement",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "organisme_recenseur",

--- a/data/wfs/BDTOPO_V3/aerodrome.json
+++ b/data/wfs/BDTOPO_V3/aerodrome.json
@@ -39,19 +39,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/arrondissement.json
+++ b/data/wfs/BDTOPO_V3/arrondissement.json
@@ -35,19 +35,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "geometrie",

--- a/data/wfs/BDTOPO_V3/arrondissement_municipal.json
+++ b/data/wfs/BDTOPO_V3/arrondissement_municipal.json
@@ -27,19 +27,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "lien_vers_chef_lieu",

--- a/data/wfs/BDTOPO_V3/bassin_versant_topographique.json
+++ b/data/wfs/BDTOPO_V3/bassin_versant_topographique.json
@@ -55,19 +55,19 @@
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "libelle_du_bassin_hydrographique",

--- a/data/wfs/BDTOPO_V3/batiment.json
+++ b/data/wfs/BDTOPO_V3/batiment.json
@@ -31,19 +31,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/canalisation.json
+++ b/data/wfs/BDTOPO_V3/canalisation.json
@@ -23,19 +23,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/cimetiere.json
+++ b/data/wfs/BDTOPO_V3/cimetiere.json
@@ -35,19 +35,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/collectivite_territoriale.json
+++ b/data/wfs/BDTOPO_V3/collectivite_territoriale.json
@@ -27,19 +27,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "liens_vers_autorite_administrative",

--- a/data/wfs/BDTOPO_V3/commune.json
+++ b/data/wfs/BDTOPO_V3/commune.json
@@ -43,19 +43,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "code_postal",
@@ -87,7 +87,7 @@
     },
     {
       "name": "date_du_recensement",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "organisme_recenseur",

--- a/data/wfs/BDTOPO_V3/commune_associee_ou_deleguee.json
+++ b/data/wfs/BDTOPO_V3/commune_associee_ou_deleguee.json
@@ -31,19 +31,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "code_postal",

--- a/data/wfs/BDTOPO_V3/condominium.json
+++ b/data/wfs/BDTOPO_V3/condominium.json
@@ -15,19 +15,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "lien_vers_lieu_dit",

--- a/data/wfs/BDTOPO_V3/construction_lineaire.json
+++ b/data/wfs/BDTOPO_V3/construction_lineaire.json
@@ -35,19 +35,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/construction_ponctuelle.json
+++ b/data/wfs/BDTOPO_V3/construction_ponctuelle.json
@@ -35,19 +35,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/construction_surfacique.json
+++ b/data/wfs/BDTOPO_V3/construction_surfacique.json
@@ -35,19 +35,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/cours_d_eau.json
+++ b/data/wfs/BDTOPO_V3/cours_d_eau.json
@@ -27,19 +27,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/departement.json
+++ b/data/wfs/BDTOPO_V3/departement.json
@@ -27,19 +27,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "liens_vers_autorite_administrative",

--- a/data/wfs/BDTOPO_V3/detail_hydrographique.json
+++ b/data/wfs/BDTOPO_V3/detail_hydrographique.json
@@ -39,19 +39,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/detail_orographique.json
+++ b/data/wfs/BDTOPO_V3/detail_orographique.json
@@ -31,19 +31,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/epci.json
+++ b/data/wfs/BDTOPO_V3/epci.json
@@ -23,19 +23,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "codes_insee_des_communes_membres",

--- a/data/wfs/BDTOPO_V3/equipement_de_transport.json
+++ b/data/wfs/BDTOPO_V3/equipement_de_transport.json
@@ -47,19 +47,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/foret_publique.json
+++ b/data/wfs/BDTOPO_V3/foret_publique.json
@@ -27,19 +27,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/haie.json
+++ b/data/wfs/BDTOPO_V3/haie.json
@@ -11,19 +11,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "hauteur",

--- a/data/wfs/BDTOPO_V3/itineraire_autre.json
+++ b/data/wfs/BDTOPO_V3/itineraire_autre.json
@@ -31,19 +31,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/lieu_dit_non_habite.json
+++ b/data/wfs/BDTOPO_V3/lieu_dit_non_habite.json
@@ -27,19 +27,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/ligne_electrique.json
+++ b/data/wfs/BDTOPO_V3/ligne_electrique.json
@@ -27,19 +27,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/ligne_orographique.json
+++ b/data/wfs/BDTOPO_V3/ligne_orographique.json
@@ -19,19 +19,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "toponyme",

--- a/data/wfs/BDTOPO_V3/limite_terre_mer.json
+++ b/data/wfs/BDTOPO_V3/limite_terre_mer.json
@@ -27,19 +27,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/noeud_hydrographique.json
+++ b/data/wfs/BDTOPO_V3/noeud_hydrographique.json
@@ -31,19 +31,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/non_communication.json
+++ b/data/wfs/BDTOPO_V3/non_communication.json
@@ -11,19 +11,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "lien_vers_troncon_entree",

--- a/data/wfs/BDTOPO_V3/parc_ou_reserve.json
+++ b/data/wfs/BDTOPO_V3/parc_ou_reserve.json
@@ -35,19 +35,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/piste_d_aerodrome.json
+++ b/data/wfs/BDTOPO_V3/piste_d_aerodrome.json
@@ -23,19 +23,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/plan_d_eau.json
+++ b/data/wfs/BDTOPO_V3/plan_d_eau.json
@@ -31,19 +31,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/point_d_acces.json
+++ b/data/wfs/BDTOPO_V3/point_d_acces.json
@@ -11,19 +11,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "methode_d_acquisition_planimetrique",

--- a/data/wfs/BDTOPO_V3/point_de_repere.json
+++ b/data/wfs/BDTOPO_V3/point_de_repere.json
@@ -11,19 +11,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/point_du_reseau.json
+++ b/data/wfs/BDTOPO_V3/point_du_reseau.json
@@ -35,19 +35,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/poste_de_transformation.json
+++ b/data/wfs/BDTOPO_V3/poste_de_transformation.json
@@ -27,19 +27,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/pylone.json
+++ b/data/wfs/BDTOPO_V3/pylone.json
@@ -19,19 +19,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/region.json
+++ b/data/wfs/BDTOPO_V3/region.json
@@ -23,19 +23,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "liens_vers_autorite_administrative",

--- a/data/wfs/BDTOPO_V3/reservoir.json
+++ b/data/wfs/BDTOPO_V3/reservoir.json
@@ -19,19 +19,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/route_numerotee_ou_nommee.json
+++ b/data/wfs/BDTOPO_V3/route_numerotee_ou_nommee.json
@@ -27,19 +27,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/section_de_points_de_repere.json
+++ b/data/wfs/BDTOPO_V3/section_de_points_de_repere.json
@@ -39,15 +39,15 @@
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "geometrie",

--- a/data/wfs/BDTOPO_V3/surface_hydrographique.json
+++ b/data/wfs/BDTOPO_V3/surface_hydrographique.json
@@ -31,19 +31,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/terrain_de_sport.json
+++ b/data/wfs/BDTOPO_V3/terrain_de_sport.json
@@ -23,19 +23,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/toponymie.json
+++ b/data/wfs/BDTOPO_V3/toponymie.json
@@ -31,7 +31,7 @@
     },
     {
       "name": "date_du_toponyme",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "langue_du_toponyme",

--- a/data/wfs/BDTOPO_V3/transport_par_cable.json
+++ b/data/wfs/BDTOPO_V3/transport_par_cable.json
@@ -31,19 +31,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/troncon_de_route.json
+++ b/data/wfs/BDTOPO_V3/troncon_de_route.json
@@ -39,19 +39,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",
@@ -183,7 +183,7 @@
     },
     {
       "name": "date_de_mise_en_service",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "liens_vers_route_nommee",

--- a/data/wfs/BDTOPO_V3/troncon_de_voie_ferree.json
+++ b/data/wfs/BDTOPO_V3/troncon_de_voie_ferree.json
@@ -23,19 +23,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/troncon_hydrographique.json
+++ b/data/wfs/BDTOPO_V3/troncon_hydrographique.json
@@ -35,19 +35,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/voie_ferree_nommee.json
+++ b/data/wfs/BDTOPO_V3/voie_ferree_nommee.json
@@ -19,19 +19,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/voie_nommee.json
+++ b/data/wfs/BDTOPO_V3/voie_nommee.json
@@ -59,11 +59,11 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "nom_normalise",

--- a/data/wfs/BDTOPO_V3/zone_d_activite_ou_d_interet.json
+++ b/data/wfs/BDTOPO_V3/zone_d_activite_ou_d_interet.json
@@ -43,19 +43,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/zone_d_estran.json
+++ b/data/wfs/BDTOPO_V3/zone_d_estran.json
@@ -15,19 +15,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/zone_d_habitation.json
+++ b/data/wfs/BDTOPO_V3/zone_d_habitation.json
@@ -39,19 +39,19 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "sources",

--- a/data/wfs/BDTOPO_V3/zone_de_vegetation.json
+++ b/data/wfs/BDTOPO_V3/zone_de_vegetation.json
@@ -11,11 +11,11 @@
     },
     {
       "name": "date_d_apparition",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "date_de_confirmation",
-      "type": "string"
+      "type": "date"
     },
     {
       "name": "methode_d_acquisition_planimetrique",
@@ -39,11 +39,11 @@
     },
     {
       "name": "date_creation",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "date_modification",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "geometrie",

--- a/data/wfs/wfs_du/doc_urba.json
+++ b/data/wfs/wfs_du/doc_urba.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",
@@ -93,6 +93,14 @@
       "name": "the_geom",
       "type": "geometry",
       "defaultCrs": "EPSG:4326"
+    },
+    {
+      "name": "nomrapp",
+      "type": "string"
+    },
+    {
+      "name": "urlrapp",
+      "type": "string"
     }
   ]
 }

--- a/data/wfs/wfs_du/doc_urba_com.json
+++ b/data/wfs/wfs_du/doc_urba_com.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_du/document.json
+++ b/data/wfs/wfs_du/document.json
@@ -35,7 +35,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_du/habillage_lin.json
+++ b/data/wfs/wfs_du/habillage_lin.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_du/habillage_pct.json
+++ b/data/wfs/wfs_du/habillage_pct.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_du/habillage_surf.json
+++ b/data/wfs/wfs_du/habillage_surf.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_du/habillage_txt.json
+++ b/data/wfs/wfs_du/habillage_txt.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_du/info_lin.json
+++ b/data/wfs/wfs_du/info_lin.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_du/info_pct.json
+++ b/data/wfs/wfs_du/info_pct.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_du/info_surf.json
+++ b/data/wfs/wfs_du/info_surf.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_du/mec.json
+++ b/data/wfs/wfs_du/mec.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "gpu_doc_id",

--- a/data/wfs/wfs_du/prescription_lin.json
+++ b/data/wfs/wfs_du/prescription_lin.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_du/prescription_pct.json
+++ b/data/wfs/wfs_du/prescription_pct.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_du/prescription_surf.json
+++ b/data/wfs/wfs_du/prescription_surf.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_du/secteur_cc.json
+++ b/data/wfs/wfs_du/secteur_cc.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_du/zone_urba.json
+++ b/data/wfs/wfs_du/zone_urba.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_scot/doc_urba.json
+++ b/data/wfs/wfs_scot/doc_urba.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_scot/doc_urba_com.json
+++ b/data/wfs/wfs_scot/doc_urba_com.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_scot/perimetre_scot.json
+++ b/data/wfs/wfs_scot/perimetre_scot.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_scot/scot.json
+++ b/data/wfs/wfs_scot/scot.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_sup/acte_sup.json
+++ b/data/wfs/wfs_sup/acte_sup.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_sup/assiette_sup_l.json
+++ b/data/wfs/wfs_sup/assiette_sup_l.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "suptype",

--- a/data/wfs/wfs_sup/assiette_sup_p.json
+++ b/data/wfs/wfs_sup/assiette_sup_p.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "suptype",

--- a/data/wfs/wfs_sup/assiette_sup_s.json
+++ b/data/wfs/wfs_sup/assiette_sup_s.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "suptype",

--- a/data/wfs/wfs_sup/generateur_sup_l.json
+++ b/data/wfs/wfs_sup/generateur_sup_l.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "suptype",

--- a/data/wfs/wfs_sup/generateur_sup_p.json
+++ b/data/wfs/wfs_sup/generateur_sup_p.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "suptype",

--- a/data/wfs/wfs_sup/generateur_sup_s.json
+++ b/data/wfs/wfs_sup/generateur_sup_s.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "suptype",

--- a/data/wfs/wfs_sup/gestionnaire_sup.json
+++ b/data/wfs/wfs_sup/gestionnaire_sup.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_sup/servitude.json
+++ b/data/wfs/wfs_sup/servitude.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/data/wfs/wfs_sup/servitude_acte_sup.json
+++ b/data/wfs/wfs_sup/servitude_acte_sup.json
@@ -19,7 +19,7 @@
     },
     {
       "name": "gpu_timestamp",
-      "type": "string"
+      "type": "date-time"
     },
     {
       "name": "partition",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ignfab/gpf-schema-store",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ignfab/gpf-schema-store",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@camptocamp/ogc-client": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Experimental OGC API Features schema store enriched from Geoplateforme WFS.",
   "license": "MIT",
   "author": "IGNF",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "engines": {
     "node": ">=22"
   },

--- a/src/ogc-api-feature/writer.ts
+++ b/src/ogc-api-feature/writer.ts
@@ -74,7 +74,7 @@ function toJsonSchemaTypeAndFormat(type: CollectionPropertyType): {
     case 'multipoint':
       return {format: 'geometry-multipoint'};
     case 'geometry':
-      return {format: 'geometry-geometry'};
+      return {format: 'geometry-any'};
   }
 }
 

--- a/src/ogc-api-feature/writer.ts
+++ b/src/ogc-api-feature/writer.ts
@@ -44,26 +44,40 @@ function isOgcIdentifierProperty(property: EnrichedCollectionProperty): boolean 
  * =============================================================================
  */
 
-function toJsonSchemaScalarType(type: CollectionPropertyType): OgcCollectionProperty['type'] {
+function toJsonSchemaTypeAndFormat(type: CollectionPropertyType): {
+  type?: OgcCollectionProperty['type'];
+  format?: string;
+} {
   switch (type) {
     case 'string':
-      return 'string';
+      return {type: 'string'};
     case 'boolean':
-      return 'boolean';
+      return {type: 'boolean'};
     case 'integer':
-      return 'integer';
+      return {type: 'integer'};
     case 'float':
-      return 'number';
+      return {type: 'number'};
+    case 'date':
+      return {type: 'string', format: 'date'};
+    case 'date-time':
+      return {type: 'string', format: 'date-time'};
     case 'point':
+      return {format: 'geometry-point'};
     case 'linestring':
+      return {format: 'geometry-linestring'};
     case 'polygon':
+      return {format: 'geometry-polygon'};
     case 'multilinestring':
+      return {format: 'geometry-multilinestring'};
     case 'multipolygon':
+      return {format: 'geometry-multipolygon'};
     case 'multipoint':
+      return {format: 'geometry-multipoint'};
     case 'geometry':
-      return undefined;
+      return {format: 'geometry-geometry'};
   }
 }
+
 
 function renderProperty(property: EnrichedCollectionProperty): OgcCollectionProperty {
   const rendered: OgcCollectionProperty = {};
@@ -79,10 +93,15 @@ function renderProperty(property: EnrichedCollectionProperty): OgcCollectionProp
     rendered.oneOf = structuredClone(property.oneOf);
   }
 
-  // Geometry properties are rendered as logical geometry fields rather than
-  // standard JSON Schema scalar types.
+  const {type, format} = toJsonSchemaTypeAndFormat(property.type);
+  if (type !== undefined) {
+    rendered.type = type;
+  }
+  if (format !== undefined) {
+    rendered.format = format;
+  }
+
   if (isGeometryType(property.type)) {
-    rendered.format = `geometry-${property.type}`;
     rendered['x-ogc-role'] = 'primary-geometry';
     if (property.defaultCrs !== undefined) {
       rendered['x-ign-defaultCrs'] = property.defaultCrs;
@@ -90,8 +109,6 @@ function renderProperty(property: EnrichedCollectionProperty): OgcCollectionProp
     return rendered;
   }
 
-  // Non-geometry properties are rendered with a standard JSON Schema type.
-  rendered.type = toJsonSchemaScalarType(property.type);
   if (isOgcIdentifierProperty(property)) {
     rendered['x-ogc-role'] = 'id';
   }

--- a/src/pivot/types.ts
+++ b/src/pivot/types.ts
@@ -12,6 +12,8 @@ const SCALAR_PROPERTY_TYPES = [
   'boolean',
   'float',   // WARNING : number with TableSchema and JsonSchema (API FEATURE)
   'integer',
+  'date',
+  'date-time'
 ] as const;
 
 const GEOMETRY_PROPERTY_TYPES = [

--- a/src/source/wfs/mapping.ts
+++ b/src/source/wfs/mapping.ts
@@ -24,16 +24,8 @@ const MAPPING: Record<string, CollectionPropertyType> = {
     'multipolygon': 'multipolygon',
     'multipoint': 'multipoint',
     'geometry': 'geometry',
-
-    /*
-     * WARNING : data loss
-     * 
-     * TODO : date and date-time to CollectionPropertyType
-     * 
-     * @see https://github.com/ignfab/gpf-schema-store/issues/37
-     */
-    'date': 'string',
-    'date-time': 'string',
+    'date': 'date',
+    'date-time': 'date-time',
 };
 
 


### PR DESCRIPTION
**Schema improvements for date fields:**

* Keep track of "format": "date-time" and "format": "date" from WFS DescribeFeatureType
* Update catalog 

> `"format": "date-time"` and `"format": "date"` is added to `date_creation`, `date_modification`, `date_d_apparition`, and `date_de_confirmation` fields in various BDTOPO_V3 schema files, improving the precision and validation of these fields.

(refs #37)