### PR TITLE
chore: remove x-ign-defaultCrs and x-collection-id 

### DIFF
--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2025:arrondissement",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Arrondissement",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Arrondissement ; Édition 2025-01-01",
@@ -29,8 +28,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2025:arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Arrondissement municipal",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Arrondissement municipal ; Édition 2025-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/canton.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2025:canton",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Canton",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Canton ; Édition 2025-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_d_arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_d_arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2025:chef_lieu_d_arrondissement",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu d'Arrondissement",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu d'Arrondissement ; Édition 2025-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_d_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_d_arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2025:chef_lieu_d_arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu d'Arrondissement municipal",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu d'Arrondissement municipal ; Édition 2025-01-01",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2025:chef_lieu_de_collectivite_territoriale",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de Collectivité territoriale",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de Collectivité territoriale ; Édition 2025-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2025:chef_lieu_de_commune",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu commune",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de commune ; Édition 2025-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2025:chef_lieu_de_commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de Commune associée ou déléguée ; Édition 2025-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_departement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2025:chef_lieu_de_departement",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de Département",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de Département ; Édition 2025-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_region.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2025:chef_lieu_de_region",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de Région",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de Région ; Édition 2025-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2025:collectivite_territoriale",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Collectivité territoriale",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Collectivité territoriale ; Édition 2025-01-01",
@@ -26,8 +25,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2025:commune",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Commune",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Commune ; Édition 2025-01-01",
@@ -54,8 +53,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2025:commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Commune associée ou déléguée ; Édition 2025-01-01",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2025:departement",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Département",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Département ; Édition 2025-01-01",
@@ -26,8 +25,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/epci.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2025:epci",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 EPCI",
   "description": "ADMINEXPRESS COG CARTO PE 2025 EPCI ; Édition 2025-01-01",
@@ -29,8 +28,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/region.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2025:region",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Région",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Région ; Édition 2025-01-01",
@@ -23,8 +22,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2026:arrondissement",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Arrondissement",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Arrondissement ; Édition 2026-01-01",
@@ -29,8 +28,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2026:arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Arrondissement municipal",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Arrondissement municipal ; Édition 2026-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/canton.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2026:canton",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Canton",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Canton ; Édition 2026-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_d_arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_d_arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2026:chef_lieu_d_arrondissement",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu d'Arrondissement",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu d'Arrondissement ; Édition 2026-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_d_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_d_arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2026:chef_lieu_d_arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu d'Arrondissement municipal",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu d'Arrondissement municipal ; Édition 2026-01-01",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2026:chef_lieu_de_collectivite_territoriale",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de Collectivité territoriale",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de Collectivité territoriale ; Édition 2026-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2026:chef_lieu_de_commune",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu commune",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de commune ; Édition 2026-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2026:chef_lieu_de_commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de Commune associée ou déléguée ; Édition 2026-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_departement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2026:chef_lieu_de_departement",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de Département",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de Département ; Édition 2026-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_region.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2026:chef_lieu_de_region",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de Région",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de Région ; Édition 2026-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2026:collectivite_territoriale",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Collectivité territoriale",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Collectivité territoriale ; Édition 2026-01-01",
@@ -26,8 +25,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2026:commune",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Commune",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Commune ; Édition 2026-01-01",
@@ -54,8 +53,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2026:commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Commune associée ou déléguée ; Édition 2026-01-01",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2026:departement",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Département",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Département ; Édition 2026-01-01",
@@ -26,8 +25,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/epci.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2026:epci",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 EPCI",
   "description": "ADMINEXPRESS COG CARTO PE 2026 EPCI ; Édition 2026-01-01",
@@ -29,8 +28,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/region.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.2026:region",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Région",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Région ; Édition 2026-01-01",
@@ -23,8 +22,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.LATEST:arrondissement",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Arrondissement",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Arrondissement",
@@ -29,8 +28,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.LATEST:arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Arrondissement municipal",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Arrondissement municipal",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/canton.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.LATEST:canton",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Canton",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Canton",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_d_arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_d_arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.LATEST:chef_lieu_d_arrondissement",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu d'Arrondissement",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu d'Arrondissement",
@@ -38,8 +37,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_d_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_d_arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.LATEST:chef_lieu_d_arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu d'Arrondissement municipal",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu d'Arrondissement municipal",
@@ -41,8 +40,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.LATEST:chef_lieu_de_collectivite_territoriale",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de Collectivité territoriale",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de Collectivité territoriale",
@@ -41,8 +40,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.LATEST:chef_lieu_de_commune",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu commune",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de commune",
@@ -38,8 +37,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.LATEST:chef_lieu_de_commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de Commune associée ou déléguée",
@@ -38,8 +37,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_departement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.LATEST:chef_lieu_de_departement",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de Département",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de Département",
@@ -38,8 +37,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_region.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.LATEST:chef_lieu_de_region",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de Région",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de Région",
@@ -38,8 +37,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.LATEST:collectivite_territoriale",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Collectivité territoriale",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Collectivité territoriale",
@@ -26,8 +25,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.LATEST:commune",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Commune",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Commune",
@@ -57,8 +56,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.LATEST:commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Commune associée ou déléguée",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.LATEST:departement",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Département",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Département",
@@ -26,8 +25,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/epci.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.LATEST:epci",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition EPCI",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition EPCI",
@@ -29,8 +28,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/region.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG-CARTO-PE.LATEST:region",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Région",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Région",
@@ -23,8 +22,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2017/arrondissement_departemental.json
+++ b/data/catalog/ADMINEXPRESS-COG.2017/arrondissement_departemental.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2017:arrondissement_departemental",
   "type": "object",
   "title": "ADMINEXPRESS COG 2017 Arrondissement départemental",
   "description": "ADMINEXPRESS COG 2017 Arrondissement départemental ; Édition 2017-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2017/chef_lieu.json
+++ b/data/catalog/ADMINEXPRESS-COG.2017/chef_lieu.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2017:chef_lieu",
   "type": "object",
   "title": "ADMINEXPRESS COG 2017 Chef-lieu",
   "description": "ADMINEXPRESS COG 2017 Chef-lieu ; Édition 2017-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2017/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2017/commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2017:commune",
   "type": "object",
   "title": "ADMINEXPRESS COG 2017 Commune",
   "description": "ADMINEXPRESS COG 2017 Commune ; Édition 2017-01-01",
@@ -40,8 +39,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2017/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2017/departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2017:departement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2017 Département",
   "description": "ADMINEXPRESS COG 2017 Département ; Édition 2017-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2017/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2017/epci.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2017:epci",
   "type": "object",
   "title": "ADMINEXPRESS COG 2017 EPCI",
   "description": "ADMINEXPRESS COG 2017 EPCI ; Édition 2017-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2017/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2017/region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2017:region",
   "type": "object",
   "title": "ADMINEXPRESS COG 2017 Région",
   "description": "ADMINEXPRESS COG 2017 Région ; Édition 2017-01-01",
@@ -16,8 +15,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2018/arrondissement_departemental.json
+++ b/data/catalog/ADMINEXPRESS-COG.2018/arrondissement_departemental.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2018:arrondissement_departemental",
   "type": "object",
   "title": "ADMINEXPRESS COG 2018 Arrondissement départemental",
   "description": "ADMINEXPRESS COG 2018 Arrondissement départemental ; Édition 2018-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2018/chef_lieu.json
+++ b/data/catalog/ADMINEXPRESS-COG.2018/chef_lieu.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2018:chef_lieu",
   "type": "object",
   "title": "ADMINEXPRESS COG 2018 Chef-lieu",
   "description": "ADMINEXPRESS COG 2018 Chef-lieu ; Édition 2018-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2018/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2018/commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2018:commune",
   "type": "object",
   "title": "ADMINEXPRESS COG 2018 Commune",
   "description": "ADMINEXPRESS COG 2018 Commune ; Édition 2018-01-01",
@@ -43,8 +42,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2018/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2018/departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2018:departement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2018 Département",
   "description": "ADMINEXPRESS COG 2018 Département ; Édition 2018-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2018/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2018/epci.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2018:epci",
   "type": "object",
   "title": "ADMINEXPRESS COG 2018 EPCI",
   "description": "ADMINEXPRESS COG 2018 EPCI ; Édition 2018-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2018/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2018/region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2018:region",
   "type": "object",
   "title": "ADMINEXPRESS COG 2018 Région",
   "description": "ADMINEXPRESS COG 2018 Région ; Édition 2018-01-01",
@@ -16,8 +15,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2019/arrondissement_departemental.json
+++ b/data/catalog/ADMINEXPRESS-COG.2019/arrondissement_departemental.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2019:arrondissement_departemental",
   "type": "object",
   "title": "ADMINEXPRESS COG 2019 Arrondissement départemental",
   "description": "ADMINEXPRESS COG 2019 Arrondissement départemental ; Édition 2019-01-01",
@@ -28,8 +27,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2019/chef_lieu.json
+++ b/data/catalog/ADMINEXPRESS-COG.2019/chef_lieu.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2019:chef_lieu",
   "type": "object",
   "title": "ADMINEXPRESS COG 2019 Chef-lieu",
   "description": "ADMINEXPRESS COG 2019 Chef-lieu ; Édition 2019-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2019/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2019/commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2019:commune",
   "type": "object",
   "title": "ADMINEXPRESS COG 2019 Commune",
   "description": "ADMINEXPRESS COG 2019 Commune ; Édition 2019-01-01",
@@ -40,8 +39,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2019/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2019/departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2019:departement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2019 Département",
   "description": "ADMINEXPRESS COG 2019 Département ; Édition 2019-01-01",
@@ -25,8 +24,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2019/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2019/epci.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2019:epci",
   "type": "object",
   "title": "ADMINEXPRESS COG 2019 EPCI",
   "description": "ADMINEXPRESS COG 2019 EPCI ; Édition 2019-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2019/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2019/region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2019:region",
   "type": "object",
   "title": "ADMINEXPRESS COG 2019 Région",
   "description": "ADMINEXPRESS COG 2019 Région ; Édition 2019-01-01",
@@ -22,8 +21,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2020/arrondissement_departemental.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/arrondissement_departemental.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2020:arrondissement_departemental",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 Arrondissement départemental",
   "description": "ADMINEXPRESS COG 2020 Arrondissement départemental ; Édition 2020-01-01",
@@ -28,8 +27,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2020/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2020:arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2020 Arrondissement municipal ; Édition 2020-01-01",
@@ -28,8 +27,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2020/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/canton.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2020:canton",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 Canton",
   "description": "ADMINEXPRESS COG 2020 Canton ; Édition 2020-01-01",
@@ -22,8 +21,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2020/chef_lieu.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/chef_lieu.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2020:chef_lieu",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 Chef-lieu",
   "description": "ADMINEXPRESS COG 2020 Chef-lieu ; Édition 2020-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2020/chef_lieu_entite_rattachee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/chef_lieu_entite_rattachee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2020:chef_lieu_entite_rattachee",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 Chef-lieu entité rattachée",
   "description": "ADMINEXPRESS COG 2020 Chef-lieu entité rattachée ; Édition 2020-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2020/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2020:commune",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 Commune",
   "description": "ADMINEXPRESS COG 2020 Commune ; Édition 2020-01-01",
@@ -43,8 +42,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2020/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2020:departement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 Département",
   "description": "ADMINEXPRESS COG 2020 Département ; Édition 2020-01-01",
@@ -25,8 +24,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2020/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/epci.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2020:epci",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 EPCI",
   "description": "ADMINEXPRESS COG 2020 EPCI ; Édition 2020-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2020/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2020:region",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 Région",
   "description": "ADMINEXPRESS COG 2020 Région ; Édition 2020-01-01",
@@ -22,8 +21,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2021/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2021:arrondissement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Arrondissement",
   "description": "ADMINEXPRESS COG 2021 Arrondissement ; Édition 2021-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2021/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2021:arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2021 Arrondissement municipal ; Édition 2021-01-01",
@@ -25,8 +24,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2021/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/canton.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2021:canton",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Canton",
   "description": "ADMINEXPRESS COG 2021 Canton ; Édition 2021-01-01",
@@ -22,8 +21,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2021/chef_lieu_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/chef_lieu_arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2021:chef_lieu_arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Chef-lieu Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2021 Chef-lieu Arrondissement municipal ; Édition 2021-01-01",
@@ -16,8 +15,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2021/chef_lieu_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/chef_lieu_commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2021:chef_lieu_commune",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2021 Chef-lieu commune ; Édition 2021-01-01",
@@ -16,8 +15,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2021/chef_lieu_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/chef_lieu_commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2021:chef_lieu_commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Chef-lieu Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2021 Chef-lieu Commune associée ou déléguée ; Édition 2021-01-01",
@@ -16,8 +15,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2021/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2021:collectivite_territoriale",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2021 Collectivité territoriale ; Édition 2021-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2021/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2021:commune",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Commune",
   "description": "ADMINEXPRESS COG 2021 Commune ; Édition 2021-01-01",
@@ -40,8 +39,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2021/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2021:commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2021 Commune associée ou déléguée ; Édition 2021-01-01",
@@ -28,8 +27,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2021/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2021:departement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Département",
   "description": "ADMINEXPRESS COG 2021 Département ; Édition 2021-01-01",
@@ -22,8 +21,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2021/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/epci.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2021:epci",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 EPCI",
   "description": "ADMINEXPRESS COG 2021 EPCI ; Édition 2021-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2021/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2021:region",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Région",
   "description": "ADMINEXPRESS COG 2021 Région ; Édition 2021-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2022/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2022:arrondissement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Arrondissement",
   "description": "ADMINEXPRESS COG 2022 Arrondissement ; Édition 2022-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2022/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2022:arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2022 Arrondissement municipal ; Édition 2022-01-01",
@@ -25,8 +24,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2022/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/canton.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2022:canton",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Canton",
   "description": "ADMINEXPRESS COG 2022 Canton ; Édition 2022-01-01",
@@ -22,8 +21,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2022/chef_lieu_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/chef_lieu_arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2022:chef_lieu_arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Chef-lieu Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2022 Chef-lieu Arrondissement municipal ; Édition 2022-01-01",
@@ -16,8 +15,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2022/chef_lieu_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/chef_lieu_commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2022:chef_lieu_commune",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2022 Chef-lieu commune ; Édition 2022-01-01",
@@ -16,8 +15,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2022/chef_lieu_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/chef_lieu_commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2022:chef_lieu_commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Chef-lieu Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2022 Chef-lieu Commune associée ou déléguée ; Édition 2022-01-01",
@@ -16,8 +15,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2022/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2022:collectivite_territoriale",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2022 Collectivité territoriale ; Édition 2022-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2022/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2022:commune",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Commune",
   "description": "ADMINEXPRESS COG 2022 Commune ; Édition 2022-01-01",
@@ -40,8 +39,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2022/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2022:commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2022 Commune associée ou déléguée ; Édition 2022-01-01",
@@ -28,8 +27,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2022/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2022:departement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Département",
   "description": "ADMINEXPRESS COG 2022 Département ; Édition 2022-01-01",
@@ -22,8 +21,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2022/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/epci.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2022:epci",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 EPCI",
   "description": "ADMINEXPRESS COG 2022 EPCI ; Édition 2022-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2022/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2022:region",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Région",
   "description": "ADMINEXPRESS COG 2022 Région ; Édition 2022-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2023/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2023:arrondissement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Arrondissement",
   "description": "ADMINEXPRESS COG 2023 Arrondissement ; Édition 2023-01-01",
@@ -25,8 +24,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2023/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2023:arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2023 Arrondissement municipal ; Édition 2023-01-01",
@@ -25,8 +24,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2023/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/canton.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2023:canton",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Canton",
   "description": "ADMINEXPRESS COG 2023 Canton ; Édition 2023-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2023/chef_lieu_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/chef_lieu_arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2023:chef_lieu_arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Chef-lieu Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2023 Chef-lieu Arrondissement municipal ; Édition 2023-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2023/chef_lieu_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/chef_lieu_commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2023:chef_lieu_commune",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2023 Chef-lieu commune ; Édition 2023-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2023/chef_lieu_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/chef_lieu_commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2023:chef_lieu_commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Chef-lieu Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2023 Chef-lieu Commune associée ou déléguée ; Édition 2023-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2023/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2023:collectivite_territoriale",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2023 Collectivité territoriale ; Édition 2023-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2023/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2023:commune",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Commune",
   "description": "ADMINEXPRESS COG 2023 Commune ; Édition 2023-01-01",
@@ -40,8 +39,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2023/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2023:commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2023 Commune associée ou déléguée ; Édition 2023-01-01",
@@ -28,8 +27,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2023/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2023:departement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Département",
   "description": "ADMINEXPRESS COG 2023 Département ; Édition 2023-01-01",
@@ -22,8 +21,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2023/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/epci.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2023:epci",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 EPCI",
   "description": "ADMINEXPRESS COG 2023 EPCI ; Édition 2023-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2023/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2023:region",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Région",
   "description": "ADMINEXPRESS COG 2023 Région ; Édition 2023-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2024/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2024:arrondissement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Arrondissement",
   "description": "ADMINEXPRESS COG 2024 Arrondissement ; Édition 2024-01-01",
@@ -25,8 +24,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2024/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2024:arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2024 Arrondissement municipal ; Édition 2024-01-01",
@@ -25,8 +24,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2024/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/canton.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2024:canton",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Canton",
   "description": "ADMINEXPRESS COG 2024 Canton ; Édition 2024-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2024/chef_lieu_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/chef_lieu_arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2024:chef_lieu_arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Chef-lieu Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2024 Chef-lieu Arrondissement municipal ; Édition 2024-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2024/chef_lieu_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/chef_lieu_commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2024:chef_lieu_commune",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2024 Chef-lieu commune ; Édition 2024-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2024/chef_lieu_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/chef_lieu_commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2024:chef_lieu_commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Chef-lieu Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2024 Chef-lieu Commune associée ou déléguée ; Édition 2024-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2024/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2024:collectivite_territoriale",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2024 Collectivité territoriale ; Édition 2024-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2024/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2024:commune",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Commune",
   "description": "ADMINEXPRESS COG 2024 Commune ; Édition 2024-01-01",
@@ -40,8 +39,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2024/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2024:commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2024 Commune associée ou déléguée ; Édition 2024-01-01",
@@ -28,8 +27,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2024/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2024:departement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Département",
   "description": "ADMINEXPRESS COG 2024 Département ; Édition 2024-01-01",
@@ -22,8 +21,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2024/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/epci.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2024:epci",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 EPCI",
   "description": "ADMINEXPRESS COG 2024 EPCI ; Édition 2024-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2024/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2024:region",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Région",
   "description": "ADMINEXPRESS COG 2024 Région ; Édition 2024-01-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2025/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2025:arrondissement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Arrondissement",
   "description": "ADMINEXPRESS COG 2025 Arrondissement ; Édition 2025-01-01",
@@ -29,8 +28,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2025/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2025:arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2025 Arrondissement municipal ; Édition 2025-01-01",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2025/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/canton.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2025:canton",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Canton",
   "description": "ADMINEXPRESS COG 2025 Canton ; Édition 2025-01-01",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_d_arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_d_arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2025:chef_lieu_d_arrondissement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu d'Arrondissement",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu d'Arrondissement ; Édition 2025-01-01",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_d_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_d_arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2025:chef_lieu_d_arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu d'Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu d'Arrondissement municipal ; Édition 2025-01-01",
@@ -38,8 +37,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2025:chef_lieu_de_collectivite_territoriale",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu de Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu de Collectivité territoriale ; Édition 2025-01-01",
@@ -38,8 +37,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2025:chef_lieu_de_commune",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu de commune ; Édition 2025-01-01",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2025:chef_lieu_de_commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu de Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu de Commune associée ou déléguée ; Édition 2025-01-01",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2025:chef_lieu_de_departement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu de Département",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu de Département ; Édition 2025-01-01",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2025:chef_lieu_de_region",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu de Région",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu de Région ; Édition 2025-01-01",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2025/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2025:collectivite_territoriale",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2025 Collectivité territoriale ; Édition 2025-01-01",
@@ -26,8 +25,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2025/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2025:commune",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Commune",
   "description": "ADMINEXPRESS COG 2025 Commune ; Édition 2025-01-01",
@@ -57,8 +56,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2025/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2025:commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2025 Commune associée ou déléguée ; Édition 2025-01-01",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2025/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2025:departement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Département",
   "description": "ADMINEXPRESS COG 2025 Département ; Édition 2025-01-01",
@@ -26,8 +25,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2025/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/epci.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2025:epci",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 EPCI",
   "description": "ADMINEXPRESS COG 2025 EPCI ; Édition 2025-01-01",
@@ -29,8 +28,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2025/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2025:region",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Région",
   "description": "ADMINEXPRESS COG 2025 Région ; Édition 2025-01-01",
@@ -23,8 +22,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2026/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2026:arrondissement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Arrondissement ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Arrondissement",
@@ -29,8 +28,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2026/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2026:arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Arrondissement municipal ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Arrondissement municipal",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2026/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/canton.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2026:canton",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Canton ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Canton",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_d_arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_d_arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2026:chef_lieu_d_arrondissement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu d'Arrondissement ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu d'Arrondissement",
@@ -38,8 +37,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_d_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_d_arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2026:chef_lieu_d_arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu d'Arrondissement municipal ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu d'Arrondissement municipal",
@@ -41,8 +40,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2026:chef_lieu_de_collectivite_territoriale",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu de Collectivité territoriale ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu de Collectivité territoriale",
@@ -41,8 +40,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2026:chef_lieu_de_commune",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu de commune ; édition 2026-01-01",
@@ -38,8 +37,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2026:chef_lieu_de_commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu de Commune associée ou déléguée ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu de Commune associée ou déléguée",
@@ -38,8 +37,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2026:chef_lieu_de_departement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu de Département ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu de Département",
@@ -38,8 +37,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2026:chef_lieu_de_region",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu de Région ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu de Région",
@@ -38,8 +37,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2026/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2026:collectivite_territoriale",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Collectivité territoriale ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Collectivité territoriale",
@@ -26,8 +25,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2026/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2026:commune",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Commune ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Commune",
@@ -57,8 +56,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2026/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2026:commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Commune associée ou déléguée ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Commune associée ou déléguée",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2026/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2026:departement",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Département ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Département",
@@ -26,8 +25,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2026/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/epci.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2026:epci",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 EPCI ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 EPCI",
@@ -29,8 +28,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.2026/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.2026:region",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Région ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Région",
@@ -23,8 +22,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.LATEST:arrondissement",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Arrondissement",
   "description": "ADMINEXPRESS COG Dernière édition Arrondissement",
@@ -29,8 +28,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.LATEST:arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Arrondissement municipal",
   "description": "ADMINEXPRESS COG Dernière édition Arrondissement municipal",
@@ -32,8 +31,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/canton.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.LATEST:canton",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Canton",
   "description": "ADMINEXPRESS COG Dernière édition Canton",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_d_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_d_arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.LATEST:chef_lieu_d_arrondissement_municipal",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu d Arrondissement municipal",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu d Arrondissement municipal",
@@ -41,8 +40,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_d_epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_d_epci.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.LATEST:chef_lieu_d_epci",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu d EPCI",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu d EPCI",
@@ -41,8 +40,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_canton.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.LATEST:chef_lieu_de_canton",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu de Canton",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu de Canton",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.LATEST:chef_lieu_de_collectivite_territoriale",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu de Collectivite Territoriale",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu de Collectivite Territoriale",
@@ -41,8 +40,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.LATEST:chef_lieu_de_commune",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu de commune",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu de commune",
@@ -38,8 +37,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.LATEST:chef_lieu_de_commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu de commune associée ou déléguée",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu de commune associée ou déléguée",
@@ -38,8 +37,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_region.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.LATEST:chef_lieu_de_region",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu de Region",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu de Region",
@@ -38,8 +37,7 @@
     },
     "geometrie": {
       "format": "geometry-point",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.LATEST:collectivite_territoriale",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Collectivité territoriale",
   "description": "ADMINEXPRESS COG Dernière édition Collectivité territoriale",
@@ -26,8 +25,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.LATEST:commune",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Commune",
   "description": "ADMINEXPRESS COG Dernière édition Commune",
@@ -57,8 +56,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.LATEST:commune_associee_ou_deleguee",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG Dernière édition Commune associée ou déléguée",
@@ -35,8 +34,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.LATEST:departement",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Département",
   "description": "ADMINEXPRESS COG Dernière édition Département",
@@ -26,8 +25,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/epci.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.LATEST:epci",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition EPCI",
   "description": "ADMINEXPRESS COG Dernière édition EPCI",
@@ -29,8 +28,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "ADMINEXPRESS-COG.LATEST:region",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Région",
   "description": "ADMINEXPRESS COG Dernière édition Région",
@@ -23,8 +22,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/BDTOPO_V3/aerodrome.json
+++ b/data/catalog/BDTOPO_V3/aerodrome.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:aerodrome",
   "type": "object",
   "title": "Aérodrome",
   "x-ign-theme": "Transport",
@@ -376,8 +375,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/arrondissement.json
+++ b/data/catalog/BDTOPO_V3/arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:arrondissement",
   "type": "object",
   "title": "Arrondissement",
   "x-ign-theme": "Administratif",
@@ -70,8 +69,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie GE MultiPolygone",
       "description": "Géométrie surfacique de l'objet à utiliser pour une représentation à grande échelle.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/arrondissement_municipal.json
+++ b/data/catalog/BDTOPO_V3/arrondissement_municipal.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:arrondissement_municipal",
   "type": "object",
   "title": "Arrondissement municipal",
   "x-ign-theme": "Administratif",
@@ -80,8 +79,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie GE MultiPolygone",
       "description": "Géométrie surfacique de l'objet à utiliser pour une représentation à grande échelle.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/bassin_versant_topographique.json
+++ b/data/catalog/BDTOPO_V3/bassin_versant_topographique.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:bassin_versant_topographique",
   "type": "object",
   "title": "Bassin versant topographique",
   "x-ign-theme": "Hydrographie",
@@ -336,8 +335,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/batiment.json
+++ b/data/catalog/BDTOPO_V3/batiment.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:batiment",
   "type": "object",
   "title": "Bâtiment",
   "x-ign-theme": "Bâti",
@@ -705,8 +704,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "Géométrie de l'objet.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/canalisation.json
+++ b/data/catalog/BDTOPO_V3/canalisation.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:canalisation",
   "type": "object",
   "title": "Canalisation",
   "x-ign-theme": "Services et activités",
@@ -338,8 +337,7 @@
       "format": "geometry-linestring",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/cimetiere.json
+++ b/data/catalog/BDTOPO_V3/cimetiere.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:cimetiere",
   "type": "object",
   "title": "Cimetière",
   "x-ign-theme": "Bâti",
@@ -515,8 +514,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/collectivite_territoriale.json
+++ b/data/catalog/BDTOPO_V3/collectivite_territoriale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:collectivite_territoriale",
   "type": "object",
   "title": "Collectivité territoriale",
   "x-ign-theme": "Administratif",
@@ -65,8 +64,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie GE MultiPolygone",
       "description": "Géométrie surfacique de l'objet à utiliser pour une représentation à grande échelle.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/commune.json
+++ b/data/catalog/BDTOPO_V3/commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:commune",
   "type": "object",
   "title": "Commune",
   "x-ign-theme": "Administratif",
@@ -147,8 +146,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie GE MultiPolygone",
       "description": "Géométrie surfacique de l'objet à utiliser pour une représentation à grande échelle.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/commune_associee_ou_deleguee.json
+++ b/data/catalog/BDTOPO_V3/commune_associee_ou_deleguee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:commune_associee_ou_deleguee",
   "type": "object",
   "title": "Commune associée ou déléguée",
   "x-ign-theme": "Administratif",
@@ -101,8 +100,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie GE MultiPolygone",
       "description": "Géométrie surfacique de l'objet à utiliser pour une représentation à grande échelle.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/condominium.json
+++ b/data/catalog/BDTOPO_V3/condominium.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:condominium",
   "type": "object",
   "title": "Condominium",
   "x-ign-theme": "Administratif",
@@ -50,8 +49,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie GE MultiPolygone",
       "description": "Géométrie surfacique de l'objet à utiliser pour une représentation à grande échelle.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/construction_lineaire.json
+++ b/data/catalog/BDTOPO_V3/construction_lineaire.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:construction_lineaire",
   "type": "object",
   "title": "Construction linéaire",
   "x-ign-theme": "Bâti",
@@ -690,8 +689,7 @@
       "format": "geometry-linestring",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/construction_ponctuelle.json
+++ b/data/catalog/BDTOPO_V3/construction_ponctuelle.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:construction_ponctuelle",
   "type": "object",
   "title": "Construction ponctuelle",
   "x-ign-theme": "Bâti",
@@ -560,8 +559,7 @@
       "format": "geometry-point",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/construction_surfacique.json
+++ b/data/catalog/BDTOPO_V3/construction_surfacique.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:construction_surfacique",
   "type": "object",
   "title": "Construction surfacique",
   "x-ign-theme": "Bâti",
@@ -467,8 +466,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/cours_d_eau.json
+++ b/data/catalog/BDTOPO_V3/cours_d_eau.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:cours_d_eau",
   "type": "object",
   "title": "Cours d'eau",
   "x-ign-theme": "Hydrographie",
@@ -163,8 +162,7 @@
       "format": "geometry-multilinestring",
       "title": "Géométrie GE MultiLigne",
       "description": "Champ contenant le géométrie concaténée des tronçons composant l'itinéraire dans le but de la diffusion de l'objet ROUTE_NUMEROTEE_OU_NOMMEE du produit externe.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/departement.json
+++ b/data/catalog/BDTOPO_V3/departement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:departement",
   "type": "object",
   "title": "Département",
   "x-ign-theme": "Administratif",
@@ -65,8 +64,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie GE MultiPolygone",
       "description": "Géométrie surfacique de l'objet à utiliser pour une représentation à grande échelle.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/detail_hydrographique.json
+++ b/data/catalog/BDTOPO_V3/detail_hydrographique.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:detail_hydrographique",
   "type": "object",
   "title": "Détail hydrographique",
   "x-ign-theme": "Hydrographie",
@@ -524,8 +523,7 @@
       "format": "geometry-point",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/detail_orographique.json
+++ b/data/catalog/BDTOPO_V3/detail_orographique.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:detail_orographique",
   "type": "object",
   "title": "Détail orographique",
   "x-ign-theme": "Lieux nommés",
@@ -515,8 +514,7 @@
       "format": "geometry-point",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/epci.json
+++ b/data/catalog/BDTOPO_V3/epci.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:epci",
   "type": "object",
   "title": "EPCI",
   "x-ign-theme": "Administratif",
@@ -98,8 +97,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie GE MultiPolygone",
       "description": "Géométrie surfacique de l'objet à utiliser pour une représentation à grande échelle.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/equipement_de_transport.json
+++ b/data/catalog/BDTOPO_V3/equipement_de_transport.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:equipement_de_transport",
   "type": "object",
   "title": "Equipement de transport",
   "x-ign-theme": "Transport",
@@ -810,8 +809,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/foret_publique.json
+++ b/data/catalog/BDTOPO_V3/foret_publique.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:foret_publique",
   "type": "object",
   "title": "Forêt publique",
   "x-ign-theme": "Zones réglementées",
@@ -281,8 +280,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/haie.json
+++ b/data/catalog/BDTOPO_V3/haie.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:haie",
   "type": "object",
   "title": "Haie",
   "x-ign-theme": "Occupation du sol",
@@ -200,8 +199,7 @@
       "format": "geometry-linestring",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/itineraire_autre.json
+++ b/data/catalog/BDTOPO_V3/itineraire_autre.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:itineraire_autre",
   "type": "object",
   "title": "Itinéraire autre",
   "x-ign-theme": "Transport",
@@ -166,8 +165,7 @@
       "format": "geometry-multilinestring",
       "title": "Géométrie GE MultiLigne",
       "description": "Champ contenant le géométrie concaténée des tronçons composant l'itinéraire dans le but de la diffusion de l'objet ROUTE_NUMEROTEE_OU_NOMMEE du produit externe.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/lieu_dit_non_habite.json
+++ b/data/catalog/BDTOPO_V3/lieu_dit_non_habite.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:lieu_dit_non_habite",
   "type": "object",
   "title": "Lieu-dit non habité",
   "x-ign-theme": "Lieux nommés",
@@ -320,8 +319,7 @@
       "format": "geometry-point",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/ligne_electrique.json
+++ b/data/catalog/BDTOPO_V3/ligne_electrique.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:ligne_electrique",
   "type": "object",
   "title": "Ligne électrique",
   "x-ign-theme": "Services et activités",
@@ -356,8 +355,7 @@
       "format": "geometry-linestring",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/ligne_orographique.json
+++ b/data/catalog/BDTOPO_V3/ligne_orographique.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:ligne_orographique",
   "type": "object",
   "title": "Ligne orographique",
   "x-ign-theme": "Bâti",
@@ -377,8 +376,7 @@
       "format": "geometry-linestring",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/limite_terre_mer.json
+++ b/data/catalog/BDTOPO_V3/limite_terre_mer.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:limite_terre_mer",
   "type": "object",
   "title": "Limite terre-mer",
   "x-ign-theme": "Hydrographie",
@@ -371,8 +370,7 @@
       "format": "geometry-linestring",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/noeud_hydrographique.json
+++ b/data/catalog/BDTOPO_V3/noeud_hydrographique.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:noeud_hydrographique",
   "type": "object",
   "title": "Noeud hydrographique",
   "x-ign-theme": "Hydrographie",
@@ -535,8 +534,7 @@
       "format": "geometry-point",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/non_communication.json
+++ b/data/catalog/BDTOPO_V3/non_communication.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:non_communication",
   "type": "object",
   "title": "Non-communication",
   "x-ign-theme": "Transport",
@@ -51,8 +50,7 @@
       "format": "geometry-point",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/parc_ou_reserve.json
+++ b/data/catalog/BDTOPO_V3/parc_ou_reserve.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:parc_ou_reserve",
   "type": "object",
   "title": "Parc ou réserve",
   "x-ign-theme": "Zones réglementées",
@@ -479,8 +478,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/piste_d_aerodrome.json
+++ b/data/catalog/BDTOPO_V3/piste_d_aerodrome.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:piste_d_aerodrome",
   "type": "object",
   "title": "Piste d'aérodrome",
   "x-ign-theme": "Transport",
@@ -361,8 +360,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/plan_d_eau.json
+++ b/data/catalog/BDTOPO_V3/plan_d_eau.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:plan_d_eau",
   "type": "object",
   "title": "Plan d'eau",
   "x-ign-theme": "Hydrographie",
@@ -475,8 +474,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie GE MultiPolygone",
       "description": "Géométrie surfacique de l'objet à utiliser pour une représentation à grande échelle.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/point_d_acces.json
+++ b/data/catalog/BDTOPO_V3/point_d_acces.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:point_d_acces",
   "type": "object",
   "title": "Point d'accès",
   "x-ign-theme": "Transport",
@@ -229,8 +228,7 @@
       "format": "geometry-point",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/point_de_repere.json
+++ b/data/catalog/BDTOPO_V3/point_de_repere.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:point_de_repere",
   "type": "object",
   "title": "Point de repère",
   "x-ign-theme": "Transport",
@@ -182,8 +181,7 @@
       "format": "geometry-point",
       "title": "Géométrie",
       "description": "Géométrie de l'objet.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/point_du_reseau.json
+++ b/data/catalog/BDTOPO_V3/point_du_reseau.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:point_du_reseau",
   "type": "object",
   "title": "Point du réseau",
   "x-ign-theme": "Transport",
@@ -425,8 +424,7 @@
       "format": "geometry-point",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/poste_de_transformation.json
+++ b/data/catalog/BDTOPO_V3/poste_de_transformation.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:poste_de_transformation",
   "type": "object",
   "title": "Poste de transformation",
   "x-ign-theme": "Services et activités",
@@ -377,8 +376,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/pylone.json
+++ b/data/catalog/BDTOPO_V3/pylone.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:pylone",
   "type": "object",
   "title": "Pylône",
   "x-ign-theme": "Bâti",
@@ -314,8 +313,7 @@
       "format": "geometry-point",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/region.json
+++ b/data/catalog/BDTOPO_V3/region.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:region",
   "type": "object",
   "title": "Région",
   "x-ign-theme": "Administratif",
@@ -60,8 +59,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie GE MultiPolygone",
       "description": "Géométrie surfacique de l'objet à utiliser pour une représentation à grande échelle.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/reservoir.json
+++ b/data/catalog/BDTOPO_V3/reservoir.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:reservoir",
   "type": "object",
   "title": "Réservoir",
   "x-ign-theme": "Bâti",
@@ -404,8 +403,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/route_numerotee_ou_nommee.json
+++ b/data/catalog/BDTOPO_V3/route_numerotee_ou_nommee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:route_numerotee_ou_nommee",
   "type": "object",
   "title": "Route numérotée ou nommée",
   "x-ign-theme": "Transport",
@@ -1947,8 +1946,7 @@
       "format": "geometry-multilinestring",
       "title": "Géométrie GE MultiLigne",
       "description": "Champ contenant le géométrie concaténée des tronçons composant l'itinéraire dans le but de la diffusion de l'objet ROUTE_NUMEROTEE_OU_NOMMEE du produit externe.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/section_de_points_de_repere.json
+++ b/data/catalog/BDTOPO_V3/section_de_points_de_repere.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:section_de_points_de_repere",
   "type": "object",
   "title": "Section de points de repère",
   "x-ign-theme": "Transport",
@@ -83,8 +82,7 @@
       "format": "geometry-linestring",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/surface_hydrographique.json
+++ b/data/catalog/BDTOPO_V3/surface_hydrographique.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:surface_hydrographique",
   "type": "object",
   "title": "Surface hydrographique",
   "x-ign-theme": "Hydrographie",
@@ -801,8 +800,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/terrain_de_sport.json
+++ b/data/catalog/BDTOPO_V3/terrain_de_sport.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:terrain_de_sport",
   "type": "object",
   "title": "Terrain de sport",
   "x-ign-theme": "Bâti",
@@ -457,8 +456,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/toponymie.json
+++ b/data/catalog/BDTOPO_V3/toponymie.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:toponymie",
   "type": "object",
   "title": "Toponymie",
   "x-ign-theme": "Lieux nommés",
@@ -83,8 +82,7 @@
       "format": "geometry-point",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/transport_par_cable.json
+++ b/data/catalog/BDTOPO_V3/transport_par_cable.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:transport_par_cable",
   "type": "object",
   "title": "Transport par câble",
   "x-ign-theme": "Transport",
@@ -440,8 +439,7 @@
       "format": "geometry-linestring",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/troncon_de_route.json
+++ b/data/catalog/BDTOPO_V3/troncon_de_route.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:troncon_de_route",
   "type": "object",
   "title": "Tronçon de route",
   "x-ign-theme": "Transport",
@@ -1297,8 +1296,7 @@
       "format": "geometry-linestring",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/troncon_de_voie_ferree.json
+++ b/data/catalog/BDTOPO_V3/troncon_de_voie_ferree.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:troncon_de_voie_ferree",
   "type": "object",
   "title": "Tronçon de voie ferrée",
   "x-ign-theme": "Transport",
@@ -528,8 +527,7 @@
       "format": "geometry-linestring",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/troncon_hydrographique.json
+++ b/data/catalog/BDTOPO_V3/troncon_hydrographique.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:troncon_hydrographique",
   "type": "object",
   "title": "Tronçon hydrographique",
   "x-ign-theme": "Hydrographie",
@@ -978,8 +977,7 @@
       "format": "geometry-linestring",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/voie_ferree_nommee.json
+++ b/data/catalog/BDTOPO_V3/voie_ferree_nommee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:voie_ferree_nommee",
   "type": "object",
   "title": "Voie ferrée nommée",
   "x-ign-theme": "Transport",
@@ -88,8 +87,7 @@
       "format": "geometry-multilinestring",
       "title": "Géométrie GE MultiLigne",
       "description": "Champ contenant le géométrie concaténée des tronçons composant l'itinéraire dans le but de la diffusion de l'objet ROUTE_NUMEROTEE_OU_NOMMEE du produit externe.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/voie_nommee.json
+++ b/data/catalog/BDTOPO_V3/voie_nommee.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:voie_nommee",
   "type": "object",
   "title": "Voie nommée",
   "x-ign-theme": "Adresses",
@@ -98,8 +97,7 @@
       "format": "geometry-multilinestring",
       "title": "Géométrie",
       "description": "Champ contenant le géométrie concaténée des tronçons composant la voie nommée.",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/zone_d_activite_ou_d_interet.json
+++ b/data/catalog/BDTOPO_V3/zone_d_activite_ou_d_interet.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:zone_d_activite_ou_d_interet",
   "type": "object",
   "title": "Zone d'activité ou d'intérêt",
   "x-ign-theme": "Services et activités",
@@ -3729,8 +3728,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/zone_d_estran.json
+++ b/data/catalog/BDTOPO_V3/zone_d_estran.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:zone_d_estran",
   "type": "object",
   "title": "Zone d'estran",
   "x-ign-theme": "Occupation du sol",
@@ -223,8 +222,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/zone_d_habitation.json
+++ b/data/catalog/BDTOPO_V3/zone_d_habitation.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:zone_d_habitation",
   "type": "object",
   "title": "Zone d'habitation",
   "x-ign-theme": "Lieux nommés",
@@ -482,8 +481,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/BDTOPO_V3/zone_de_vegetation.json
+++ b/data/catalog/BDTOPO_V3/zone_de_vegetation.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "BDTOPO_V3:zone_de_vegetation",
   "type": "object",
   "title": "Zone de végétation",
   "x-ign-theme": "Occupation du sol",
@@ -352,8 +351,7 @@
       "format": "geometry-multipolygon",
       "title": "Géométrie",
       "description": "",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": [

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/arrondissement.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/arrondissement.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "CADASTRALPARCELS.PARCELLAIRE_EXPRESS:arrondissement",
   "type": "object",
   "title": "PCI Vecteur : Arrondissements",
   "description": "Arrondissements ; Édition 2026-03-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/batiment.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/batiment.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "CADASTRALPARCELS.PARCELLAIRE_EXPRESS:batiment",
   "type": "object",
   "title": "PCI Vecteur : Bâtiments",
   "description": "Bâtiments ; Édition 2026-03-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/borne_limite_propriete.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/borne_limite_propriete.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "CADASTRALPARCELS.PARCELLAIRE_EXPRESS:borne_limite_propriete",
   "type": "object",
   "title": "PCI Vecteur : Bornes de limite de propriété",
   "description": "Bornes de limite de propriété ; Édition 2026-03-01",
@@ -13,8 +12,7 @@
     },
     "geom": {
       "format": "geometry-multipoint",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/borne_parcelle.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/borne_parcelle.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "CADASTRALPARCELS.PARCELLAIRE_EXPRESS:borne_parcelle",
   "type": "object",
   "title": "PCI Vecteur : Lien bornes parcelles",
   "description": "Lien bornes parcelles ; Édition 2026-03-01",
@@ -16,8 +15,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/commune.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/commune.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "CADASTRALPARCELS.PARCELLAIRE_EXPRESS:commune",
   "type": "object",
   "title": "PCI Vecteur : Communes",
   "description": "Communes ; Édition 2026-03-01",
@@ -19,8 +18,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/feuille.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/feuille.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "CADASTRALPARCELS.PARCELLAIRE_EXPRESS:feuille",
   "type": "object",
   "title": "PCI Vecteur : Feuilles",
   "description": "Feuilles ; Édition 2026-03-01",
@@ -40,8 +39,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/localisant.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/localisant.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "CADASTRALPARCELS.PARCELLAIRE_EXPRESS:localisant",
   "type": "object",
   "title": "PCI Vecteur : Localisants",
   "description": "Localisants ; Édition 2026-03-01",
@@ -37,8 +36,7 @@
     },
     "geom": {
       "format": "geometry-multipoint",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/parcelle.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/parcelle.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "CADASTRALPARCELS.PARCELLAIRE_EXPRESS:parcelle",
   "type": "object",
   "title": "PCI Vecteur : Parcelles",
   "description": "Parcelles ; Édition 2026-03-01",
@@ -43,8 +42,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/subdivision_fiscale.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/subdivision_fiscale.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "CADASTRALPARCELS.PARCELLAIRE_EXPRESS:subdivision_fiscale",
   "type": "object",
   "title": "PCI Vecteur : Subdivisions fiscales",
   "description": "Subdivisions fiscales ; Édition 2026-03-01",
@@ -16,8 +15,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/INSEE.FILOSOFI.INDICATORS/carreaux_1km.json
+++ b/data/catalog/INSEE.FILOSOFI.INDICATORS/carreaux_1km.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "INSEE.FILOSOFI.INDICATORS:carreaux_1km",
   "type": "object",
   "title": "Carroyages INSEE",
   "description": "Carroyages INSEE à 200 m, à 1 km et à la plus grande échelle diffusable ",
@@ -148,8 +147,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/INSEE.FILOSOFI.INDICATORS/carreaux_200m.json
+++ b/data/catalog/INSEE.FILOSOFI.INDICATORS/carreaux_200m.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "INSEE.FILOSOFI.INDICATORS:carreaux_200m",
   "type": "object",
   "title": "Carroyages INSEE",
   "description": "Carroyages INSEE à 200 m, à 1 km et à la plus grande échelle diffusable ",
@@ -154,8 +153,7 @@
     },
     "geom": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/STATISTICALUNITS.IRIS.PE/contours_iris_pe.json
+++ b/data/catalog/STATISTICALUNITS.IRIS.PE/contours_iris_pe.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "STATISTICALUNITS.IRIS.PE:contours_iris_pe",
   "type": "object",
   "title": "Contours géométriques des IRIS de l'INSEE à petite échelle",
   "description": "Contours géométriques des IRIS de l'INSEE à petite échelle sur toute la France ; Edition : 2026-01-01",
@@ -29,8 +28,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/STATISTICALUNITS.IRIS/contours_iris.json
+++ b/data/catalog/STATISTICALUNITS.IRIS/contours_iris.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "STATISTICALUNITS.IRIS:contours_iris",
   "type": "object",
   "title": "Contours géométriques des IRIS de l INSEE à moyenne échelle",
   "description": "Contours géométriques des IRIS de l INSEE à moyenne échelle sur toute la France ; Edition 2026-01-01",
@@ -29,8 +28,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/STATISTICALUNITS.IRISGE/iris_ge.json
+++ b/data/catalog/STATISTICALUNITS.IRISGE/iris_ge.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "STATISTICALUNITS.IRISGE:iris_ge",
   "type": "object",
   "title": "Contours géométriques des IRIS de l'INSEE à grande échelle",
   "description": "Contours géométriques des IRIS de l'INSEE à grande échelle sur toute la France ; Edition : 2026-01-01",
@@ -29,8 +28,7 @@
     },
     "geometrie": {
       "format": "geometry-multipolygon",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/wfs_du/doc_urba.json
+++ b/data/catalog/wfs_du/doc_urba.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:doc_urba",
   "type": "object",
   "title": "Document d'urbanisme",
   "description": "Classe sémantique décrivant le document d'urbanisme, données issues du Géoportail de l'urbanisme",
@@ -71,8 +70,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "nomrapp": {
       "type": "string"

--- a/data/catalog/wfs_du/doc_urba_com.json
+++ b/data/catalog/wfs_du/doc_urba_com.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:doc_urba_com",
   "type": "object",
   "title": "Document d'urbanisme",
   "description": "Classe sémantique décrivant le document d'urbanisme, données issues du Géoportail de l'urbanisme",
@@ -32,8 +31,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/wfs_du/document.json
+++ b/data/catalog/wfs_du/document.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:document",
   "type": "object",
   "title": "Document d'urbanisme",
   "description": "Emprise du document d'urbanisme, données issues du Géoportail de l'urbanisme",
@@ -38,8 +37,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/wfs_du/habillage_lin.json
+++ b/data/catalog/wfs_du/habillage_lin.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:habillage_lin",
   "type": "object",
   "title": "Habillages linéaires",
   "description": "Objet linéaire indicatif porté sur le document d'urbanisme pour l'habillage du plan, données issues du Géoportail de l'urbanisme",
@@ -41,8 +40,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/wfs_du/habillage_pct.json
+++ b/data/catalog/wfs_du/habillage_pct.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:habillage_pct",
   "type": "object",
   "title": "Habillages ponctuels",
   "description": "Objet ponctuel indicatif porté sur le document d'urbanisme pour l'habillage du plan, données issues du Géoportail de l'urbanisme",
@@ -41,8 +40,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/wfs_du/habillage_surf.json
+++ b/data/catalog/wfs_du/habillage_surf.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:habillage_surf",
   "type": "object",
   "title": "Habillages surfaciques",
   "description": "Objet surfacique indicatif porté sur le document d'urbanisme pour l'habillage du plan, données issues du Géoportail de l'urbanisme",
@@ -41,8 +40,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/wfs_du/habillage_txt.json
+++ b/data/catalog/wfs_du/habillage_txt.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:habillage_txt",
   "type": "object",
   "title": "Etiquette ponctuelle de l’habillage du plan",
   "description": "Étiquette ponctuelle portée sur le document d'urbanisme pour l’habillage du plan, données issues du Géoportail de l'urbanisme",
@@ -56,8 +55,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/wfs_du/info_lin.json
+++ b/data/catalog/wfs_du/info_lin.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:info_lin",
   "type": "object",
   "title": "Informations linéaires",
   "description": "Périmètre linéaire à reporter à titre d’information, données issues du Géoportail de l'urbanisme",
@@ -62,8 +61,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "nature": {
       "type": "string"

--- a/data/catalog/wfs_du/info_pct.json
+++ b/data/catalog/wfs_du/info_pct.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:info_pct",
   "type": "object",
   "title": "Informations ponctuelles",
   "description": "Périmètre ponctuel à reporter à titre d’information, données issues du Géoportail de l'urbanisme",
@@ -62,8 +61,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "nature": {
       "type": "string"

--- a/data/catalog/wfs_du/info_surf.json
+++ b/data/catalog/wfs_du/info_surf.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:info_surf",
   "type": "object",
   "title": "Informations surfaciques",
   "description": "Périmètre surfacique à reporter à titre d’information, données issues du Géoportail de l'urbanisme",
@@ -62,8 +61,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "nature": {
       "type": "string"

--- a/data/catalog/wfs_du/mec.json
+++ b/data/catalog/wfs_du/mec.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:mec",
   "type": "object",
   "title": "Mise en compatibilité",
   "description": "Mise en compatibilité",
@@ -41,8 +40,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/wfs_du/municipality.json
+++ b/data/catalog/wfs_du/municipality.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:municipality",
   "type": "object",
   "title": "Communes",
   "description": "Emprise communale, données issues du Géoportail de l'urbanisme",
@@ -19,8 +18,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "is_coastline": {
       "type": "boolean"

--- a/data/catalog/wfs_du/prescription_lin.json
+++ b/data/catalog/wfs_du/prescription_lin.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:prescription_lin",
   "type": "object",
   "title": "Prescriptions linéaires",
   "description": "Prescriptions linéaires se superposant au zonage, données issues du Géoportail de l'urbanisme",
@@ -59,8 +58,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "nature": {
       "type": "string"

--- a/data/catalog/wfs_du/prescription_pct.json
+++ b/data/catalog/wfs_du/prescription_pct.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:prescription_pct",
   "type": "object",
   "title": "Prescriptions ponctuelles",
   "description": "Prescriptions ponctuelles se superposant au zonage, données issues du Géoportail de l'urbanisme",
@@ -62,8 +61,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "nature": {
       "type": "string"

--- a/data/catalog/wfs_du/prescription_surf.json
+++ b/data/catalog/wfs_du/prescription_surf.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:prescription_surf",
   "type": "object",
   "title": "Prescriptions surfaciques",
   "description": "Prescriptions surfaciques se superposant au zonage, données issues du Géoportail de l'urbanisme",
@@ -59,8 +58,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "nature": {
       "type": "string"

--- a/data/catalog/wfs_du/secteur_cc.json
+++ b/data/catalog/wfs_du/secteur_cc.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:secteur_cc",
   "type": "object",
   "title": "Secteurs de la carte communale",
   "description": "Secteurs de carte communale, données issues du Géoportail de l'urbanisme",
@@ -59,8 +58,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "symbole": {
       "type": "string"

--- a/data/catalog/wfs_du/zone_urba.json
+++ b/data/catalog/wfs_du/zone_urba.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_du:zone_urba",
   "type": "object",
   "title": "Zonage du document d'urbanisme",
   "description": "Zonage du document d'urbanisme, données issues du Géoportail de l'urbanisme",
@@ -59,8 +58,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "formdomi": {
       "type": "string"

--- a/data/catalog/wfs_scot/doc_urba.json
+++ b/data/catalog/wfs_scot/doc_urba.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_scot:doc_urba",
   "type": "object",
   "title": "Document d'urbanisme",
   "description": "Classe sémantique décrivant le Schéma de Cohérence Territorial, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_scot/doc_urba_com.json
+++ b/data/catalog/wfs_scot/doc_urba_com.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_scot:doc_urba_com",
   "type": "object",
   "title": "Document d'urbanisme",
   "description": "Relations entre le Schéma de Cohérence Territorial et les communes auxquelles il s'applique, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_scot/perimetre_scot.json
+++ b/data/catalog/wfs_scot/perimetre_scot.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_scot:perimetre_scot",
   "type": "object",
   "title": "Perimetre du Schéma de cohérence territorial",
   "description": "Périmètre publié du Schéma de Cohérence Territorial, données issues du Géoportail de l'urbanisme",
@@ -26,8 +25,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/wfs_scot/scot.json
+++ b/data/catalog/wfs_scot/scot.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_scot:scot",
   "type": "object",
   "title": "Schéma de cohérence territorial",
   "description": "Etat du Schéma de Cohérence Territorial, données issues du Géoportail de l'urbanisme",
@@ -35,8 +34,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/wfs_sup/acte_sup.json
+++ b/data/catalog/wfs_sup/acte_sup.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_sup:acte_sup",
   "type": "object",
   "title": "Acte de servitude d'utilité publique",
   "description": "Liste des actes instituant une servitude d'utilité publique, données issues du Géoportail de l'urbanisme",
@@ -50,8 +49,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/wfs_sup/assiette_sup_l.json
+++ b/data/catalog/wfs_sup/assiette_sup_l.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_sup:assiette_sup_l",
   "type": "object",
   "title": "Assiette de servitude d'utilité publique",
   "description": "Assiettes linéaires liées aux servitudes, données issues du Géoportail de l'urbanisme",
@@ -62,8 +61,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "nomreg": {
       "type": "string"

--- a/data/catalog/wfs_sup/assiette_sup_p.json
+++ b/data/catalog/wfs_sup/assiette_sup_p.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_sup:assiette_sup_p",
   "type": "object",
   "title": "Assiette de servitude d'utilité publique",
   "description": "Assiettes ponctuelles liées aux servitudes, données issues du Géoportail de l'urbanisme",
@@ -62,8 +61,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "nomreg": {
       "type": "string"

--- a/data/catalog/wfs_sup/assiette_sup_s.json
+++ b/data/catalog/wfs_sup/assiette_sup_s.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_sup:assiette_sup_s",
   "type": "object",
   "title": "Assiette de servitude d'utilité publique",
   "description": "Assiettes surfaciques liées aux servitudes, données issues du Géoportail de l'urbanisme",
@@ -86,8 +85,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "nomreg": {
       "type": "string"

--- a/data/catalog/wfs_sup/generateur_sup_l.json
+++ b/data/catalog/wfs_sup/generateur_sup_l.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_sup:generateur_sup_l",
   "type": "object",
   "title": "Générateur de servitude d'utilité publique",
   "description": "Générateurs linéaires liés aux servitudes, données issues du Géoportail de l'urbanisme",
@@ -80,8 +79,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "nomreg": {
       "type": "string"

--- a/data/catalog/wfs_sup/generateur_sup_p.json
+++ b/data/catalog/wfs_sup/generateur_sup_p.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_sup:generateur_sup_p",
   "type": "object",
   "title": "Générateur de servitude d'utilité publique",
   "description": "Générateurs ponctuels liés aux servitudes, données issues du Géoportail de l'urbanisme",
@@ -68,8 +67,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "nomreg": {
       "type": "string"

--- a/data/catalog/wfs_sup/generateur_sup_s.json
+++ b/data/catalog/wfs_sup/generateur_sup_s.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_sup:generateur_sup_s",
   "type": "object",
   "title": "Générateur de servitude d'utilité publique",
   "description": "Générateurs surfaciques liés aux servitudes, données issues du Géoportail de l'urbanisme",
@@ -86,8 +85,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "nomreg": {
       "type": "string"

--- a/data/catalog/wfs_sup/gestionnaire_sup.json
+++ b/data/catalog/wfs_sup/gestionnaire_sup.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_sup:gestionnaire_sup",
   "type": "object",
   "title": "Organisme gestionnaire ou organisme ressource de la servitude",
   "description": "Gestionnaires de servitude d'utilité publique, données issues du Géoportail de l'urbanisme",
@@ -41,8 +40,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/catalog/wfs_sup/servitude.json
+++ b/data/catalog/wfs_sup/servitude.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_sup:servitude",
   "type": "object",
   "title": "Servitude d'utilité publique",
   "description": "Liste des servitudes d'utilité publique, données issues du Géoportail de l'urbanisme",
@@ -68,8 +67,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     },
     "nomreg": {
       "type": "string"

--- a/data/catalog/wfs_sup/servitude_acte_sup.json
+++ b/data/catalog/wfs_sup/servitude_acte_sup.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "x-collection-id": "wfs_sup:servitude_acte_sup",
   "type": "object",
   "title": "Relation entre ACTE_SUP et SERVITUDE",
   "description": "Relation entre les SUP et les actes les instituant, données issues du Géoportail de l'urbanisme",
@@ -29,8 +28,7 @@
     },
     "the_geom": {
       "format": "geometry-any",
-      "x-ogc-role": "primary-geometry",
-      "x-ign-defaultCrs": "EPSG:4326"
+      "x-ogc-role": "primary-geometry"
     }
   },
   "required": []

--- a/data/namespaces.csv
+++ b/data/namespaces.csv
@@ -268,6 +268,8 @@ route500logoqgis,,true,Test data,route500logoqgis
 rpg_metrolyon_epsg2154_gpkg_02-04-2026_wfs,,true,Test data,parcelles_graphiques
 sentiers_pag_gpkg_30-01-2026_wfs,,true,Test data,sentiers_PAG
 site_guadeloupe_martinique_gpkg_26-01-2026_wfs,,true,Test data,site_guadeloupe_martinique
+sites_datacenters_202607281413_csv_28-07-2026_wfs,,true,No matching rule,test_clement_sites_datacenters
+sites_datacenters_202607281413_csv_28-07-2026_wfs2,,true,No matching rule,test_clement_sites_datacenters
 sites_guyane_gpkg_26-01-2026_wfs,,true,Test data,STE_Guyane
 sites_metropole_gpkg_26-01-2026_wfs,,true,Test data,STE_Metropole
 sites_reunion_gpkg_26-01-2026_wfs,,true,Test data,STE_Reunion

--- a/docs/collection-schema.md
+++ b/docs/collection-schema.md
@@ -22,7 +22,6 @@ Implémentation :
 Each rendered file is a JSON object with these fields:
 
 - `$schema` (required): JSON Schema draft URI ("https://json-schema.org/draft/2020-12/schema").
-- `x-collection-id` (required): collection identifier (**⚠ should be removed in the futur**, see [issue #64](https://github.com/ignfab/gpf-schema-store/issues/64))
 - `type` (required): always `object`.
 - `title` (required): collection title.
 - `description` (required): collection description.
@@ -42,7 +41,6 @@ Each property entry can contain:
 - `description` (optional): property description.
 - `oneOf` (optional): list of enumerated code list values.
 - `x-ogc-role` (optional): `id` or `primary-geometry`.
-- `x-ign-defaultCrs` (optional): default CRS hint for geometry properties (**⚠ should be removed in the futur**, see [issue #64](https://github.com/ignfab/gpf-schema-store/issues/64))
 
 Geometry properties are modeled with `format: "geometry-{type}"` and `x-ogc-role: "primary-geometry"`.
 

--- a/src/ogc-api-feature/types.ts
+++ b/src/ogc-api-feature/types.ts
@@ -15,7 +15,6 @@ import { z } from 'zod';
  * 
  * Note :
  * - that "extent", "links", "crs" and "storageCrs" are ignored for now
- * - "storageCrs" is currently modeled as 'x-ign-defaultCrs' in the schema (see issue #64)
  */
 export const zOgcCollectionBrief = z.object({
   id: z.string(),
@@ -40,9 +39,6 @@ export type OgcCollectionPropertyEnumValue = z.infer<typeof zOgcCollectionProper
 
 /**
  * The JSON schema of a property
- * 
- * Note that 'x-ign-defaultCrs' should be removed in the futur (see issue #64)
- * 
  */
 export const zOgcCollectionProperty = z.object({
   type: z.enum(['string', 'boolean', 'integer', 'number']).optional(),
@@ -51,7 +47,6 @@ export const zOgcCollectionProperty = z.object({
   description: z.string().optional(),
   oneOf: z.array(zOgcCollectionPropertyEnumValue).optional(),
   'x-ogc-role': z.enum(['id', 'primary-geometry']).optional(),
-  'x-ign-defaultCrs': z.string().optional(),
 }).strict();
 
 export type OgcCollectionProperty = z.infer<typeof zOgcCollectionProperty>;
@@ -63,13 +58,11 @@ export type OgcCollectionProperty = z.infer<typeof zOgcCollectionProperty>;
  * 
  * - It should match the futur /collections/{collectionId}/schema on the GPF
  * - "id" is reserved for the schema ID as an URL
- * - "x-collection-id" is added as the collectionId (see issue #64)
  * 
  * @see https://docs.ogc.org/is/23-058r2/23-058r2.html
  */
 export const zOgcCollectionSchema = z.object({
   $schema: z.literal('https://json-schema.org/draft/2020-12/schema'),
-  'x-collection-id': z.string(),
   type: z.literal('object'),
   title: z.string(),
   'x-ign-theme': z.string().optional(),

--- a/src/ogc-api-feature/writer.ts
+++ b/src/ogc-api-feature/writer.ts
@@ -103,9 +103,6 @@ function renderProperty(property: EnrichedCollectionProperty): OgcCollectionProp
 
   if (isGeometryType(property.type)) {
     rendered['x-ogc-role'] = 'primary-geometry';
-    if (property.defaultCrs !== undefined) {
-      rendered['x-ign-defaultCrs'] = property.defaultCrs;
-    }
     return rendered;
   }
 
@@ -146,7 +143,6 @@ export function renderCollectionSchema(collection: EnrichedCollection): OgcColle
 
   const schema: Partial<OgcCollectionSchema> = {
     $schema: JSON_SCHEMA_DRAFT,
-    'x-collection-id': collection.id,
     type: 'object',
     title: collection.title,
   };

--- a/src/source/types.ts
+++ b/src/source/types.ts
@@ -14,7 +14,6 @@ import { zCollectionPropertyType } from '@/pivot/types';
 export const zSourceCollectionProperty = z.object({
   name: z.string().min(1),
   type: zCollectionPropertyType,
-  // Internal geometry hint later rendered as `x-ign-defaultCrs`.
   defaultCrs: z.string().min(1).optional(),
 }).strict();
 

--- a/test/unit/cli/render-catalog.test.ts
+++ b/test/unit/cli/render-catalog.test.ts
@@ -42,10 +42,6 @@ describe('writeRenderedCatalog', () => {
       expect.stringMatching(/[\\/]tmp[\\/]catalog[\\/]NS[\\/]feature\.json$/),
       expect.stringContaining('"$schema": "https://json-schema.org/draft/2020-12/schema"'),
     );
-    expect(fsMocks.writeFileSync).toHaveBeenCalledWith(
-      expect.stringMatching(/[\\/]tmp[\\/]catalog[\\/]NS[\\/]feature\.json$/),
-      expect.stringContaining('"x-collection-id": "NS:feature"'),
-    );
   });
 
   it('cleans the output directory when requested', async () => {

--- a/test/unit/ogc-api-feature/writer.test.ts
+++ b/test/unit/ogc-api-feature/writer.test.ts
@@ -56,7 +56,6 @@ describe('renderCollectionSchema', () => {
 
     expect(Object.keys(schema)).toEqual([
       '$schema',
-      'x-collection-id',
       'type',
       'title',
       'x-ign-theme',
@@ -75,7 +74,6 @@ describe('renderCollectionSchema', () => {
 
     expect(schema).toEqual({
       $schema: 'https://json-schema.org/draft/2020-12/schema',
-      'x-collection-id': 'NS:feature',
       type: 'object',
       title: 'Feature',
       'x-ign-theme': 'Theme',
@@ -109,8 +107,7 @@ describe('renderCollectionSchema', () => {
         geom: {
           title: 'Geometry',
           format: 'geometry-point',
-          'x-ogc-role': 'primary-geometry',
-          'x-ign-defaultCrs': 'EPSG:4326',
+          'x-ogc-role': 'primary-geometry'
         },
       },
       required: ['cleabs', 'geom'],
@@ -132,7 +129,6 @@ describe('renderCollectionSchema', () => {
 
     expect(Object.keys(schema)).toEqual([
       '$schema',
-      'x-collection-id',
       'type',
       'title',
       'x-ign-theme',
@@ -166,8 +162,7 @@ describe('renderCollectionSchema', () => {
 
     expect(pointSchema.properties.geometrie).toMatchObject({
       format: 'geometry-point',
-      'x-ogc-role': 'primary-geometry',
-      'x-ign-defaultCrs': 'EPSG:4326',
+      'x-ogc-role': 'primary-geometry'
     });
     expect(multipolygonSchema.properties.geometrie).toMatchObject({
       format: 'geometry-multipolygon',


### PR DESCRIPTION

This pull request makes schema changes across multiple files in the `data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025` and `data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026` directories. The main focus is on cleaning up metadata fields and standardizing geometry definitions. The most important changes are grouped below:

**Metadata cleanup:**

* Removed the `x-collection-id` property from all JSON schema files, simplifying the metadata in the affected schemas. [[1]](diffhunk://#diff-2ae3a23b8520345cb64c424fe981243008cd54a85117722934764d41ff34a4fbL3) [[2]](diffhunk://#diff-9111f91a892e220d1faf0084d63e4c8ea390de4366020119fa50d221f0794cf8L3) [[3]](diffhunk://#diff-551e4e6a0483416e941de1dcef779db3694cc9b7f7bb6cb5d59f7234f0643e21L3) [[4]](diffhunk://#diff-07e347c598cdae07b50fcc9dd144fc7145df7233139cc9b4a855ab8320fab0f7L3) [[5]](diffhunk://#diff-302d4366510fd29d2e17bda46fc479377fbb7785c3d84bd282f0408a0abcec6dL3) [[6]](diffhunk://#diff-b754cec24112ac1b3d729a8ce1e16eb8b5b902a4109b7cdc6f919ee6a2d849a0L3) [[7]](diffhunk://#diff-d5ca626da8cc7f258ad36e0c5d436de1e68e2ed56f3a5f9215a77d94d92f6dc7L3) [[8]](diffhunk://#diff-f1b43d0365129676a3bfe00547cf6c8404e3d016c23a8172e5bc9ac6b335cf10L3) [[9]](diffhunk://#diff-85698cc1a405bd22e6384b36d7af919fc29e64b358a31d7b651d38114b8285aaL3) [[10]](diffhunk://#diff-d734505cc8ff7e2b929e10d02d1cd3f0aa8ab31a06d0bc1197728748e290b9b9L3) [[11]](diffhunk://#diff-7fdec4a56953e74b77577aa0e88badefad1446707c05cc2e70137a458ca86cbfL3) [[12]](diffhunk://#diff-fc58fa5c7ef19ed1f48e6cd95e6ed704f04727456a997ccd541f2c4cdc7264efL3) [[13]](diffhunk://#diff-591a81a857e8384ae62a7303f6786876885d72ac308a0d2e88d21a0f0053496bL3) [[14]](diffhunk://#diff-462981260a5bcbfabd6f344d7fad1a5bacfa8dd6cd6ce66e7960c1669594db56L3) [[15]](diffhunk://#diff-1ac10fc468178a55801fda607860ddb08d9853c77dd59e9665c38c7f81830975L3) [[16]](diffhunk://#diff-34cba40ddbd0231e908df6bf256c2941535a2667fbb480b4955125406bfbe879L3) [[17]](diffhunk://#diff-7f282d9b2b6057fdc7b7aef568371ca8025ff8359004800e5338cbfd0759d9baL3) [[18]](diffhunk://#diff-af1175025aec03cee85af4f4c18f923357503598fc52611c2ce87a711af1c2f0L3) [[19]](diffhunk://#diff-4e74c177adcbb5097eca4c94220fb685e280855235e708589da9fb1b0ef4db9fL3)

**Geometry property standardization:**

* Removed the `x-ign-defaultCrs` property from all `geometrie` definitions, ensuring that only the `x-ogc-role` property remains. This reduces redundancy and potential confusion about coordinate reference systems. [[1]](diffhunk://#diff-2ae3a23b8520345cb64c424fe981243008cd54a85117722934764d41ff34a4fbL32-R31) [[2]](diffhunk://#diff-9111f91a892e220d1faf0084d63e4c8ea390de4366020119fa50d221f0794cf8L35-R34) [[3]](diffhunk://#diff-551e4e6a0483416e941de1dcef779db3694cc9b7f7bb6cb5d59f7234f0643e21L35-R34) [[4]](diffhunk://#diff-07e347c598cdae07b50fcc9dd144fc7145df7233139cc9b4a855ab8320fab0f7L35-R34) [[5]](diffhunk://#diff-302d4366510fd29d2e17bda46fc479377fbb7785c3d84bd282f0408a0abcec6dL38-R37) [[6]](diffhunk://#diff-b754cec24112ac1b3d729a8ce1e16eb8b5b902a4109b7cdc6f919ee6a2d849a0L35-R34) [[7]](diffhunk://#diff-d5ca626da8cc7f258ad36e0c5d436de1e68e2ed56f3a5f9215a77d94d92f6dc7L35-R34) [[8]](diffhunk://#diff-f1b43d0365129676a3bfe00547cf6c8404e3d016c23a8172e5bc9ac6b335cf10L35-R34) [[9]](diffhunk://#diff-85698cc1a405bd22e6384b36d7af919fc29e64b358a31d7b651d38114b8285aaL35-R34) [[10]](diffhunk://#diff-d734505cc8ff7e2b929e10d02d1cd3f0aa8ab31a06d0bc1197728748e290b9b9L35-R34) [[11]](diffhunk://#diff-7fdec4a56953e74b77577aa0e88badefad1446707c05cc2e70137a458ca86cbfL29-R28) [[12]](diffhunk://#diff-fc58fa5c7ef19ed1f48e6cd95e6ed704f04727456a997ccd541f2c4cdc7264efL57-R56) [[13]](diffhunk://#diff-591a81a857e8384ae62a7303f6786876885d72ac308a0d2e88d21a0f0053496bL38-R37) [[14]](diffhunk://#diff-462981260a5bcbfabd6f344d7fad1a5bacfa8dd6cd6ce66e7960c1669594db56L29-R28) [[15]](diffhunk://#diff-1ac10fc468178a55801fda607860ddb08d9853c77dd59e9665c38c7f81830975L32-R31) [[16]](diffhunk://#diff-34cba40ddbd0231e908df6bf256c2941535a2667fbb480b4955125406bfbe879L26-R25) [[17]](diffhunk://#diff-7f282d9b2b6057fdc7b7aef568371ca8025ff8359004800e5338cbfd0759d9baL32-R31) [[18]](diffhunk://#diff-af1175025aec03cee85af4f4c18f923357503598fc52611c2ce87a711af1c2f0L35-R34)

These changes help keep the schema definitions clean and focused, reducing unnecessary metadata and clarifying the geometry structure.

(closes #64)