### PR TITLE
Add "$id" field to catalog pointing to GH Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -21,30 +21,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build CLI
-        run: npm run build
-
-      - name: Render catalog for Pages
-        run: |
-          rm -rf site
-          npm run cli -- render-catalog site/catalog --clean
-
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: site
+          path: data
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,58 @@
+name: Deploy Catalog To GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build CLI
+        run: npm run build
+
+      - name: Render catalog for Pages
+        run: |
+          rm -rf site
+          npm run cli -- render-catalog site/catalog --clean
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/arrondissement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Arrondissement",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Arrondissement ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Arrondissement municipal",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Arrondissement municipal ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/canton.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/canton.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Canton",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Canton ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_d_arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_d_arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_d_arrondissement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu d'Arrondissement",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu d'Arrondissement ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_d_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_d_arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_d_arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu d'Arrondissement municipal",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu d'Arrondissement municipal ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_collectivite_territoriale.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de Collectivité territoriale",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de Collectivité territoriale ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu commune",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de commune ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de Commune associée ou déléguée ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_departement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de Département",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de Département ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_region.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/chef_lieu_de_region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de Région",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Chef-lieu de Région ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/collectivite_territoriale.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Collectivité territoriale",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Collectivité territoriale ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Commune",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Commune ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Commune associée ou déléguée ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Département",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Département ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/epci.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/epci.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 EPCI",
   "description": "ADMINEXPRESS COG CARTO PE 2025 EPCI ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/region.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2025/region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2025 Région",
   "description": "ADMINEXPRESS COG CARTO PE 2025 Région ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/arrondissement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Arrondissement",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Arrondissement ; Édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Arrondissement municipal",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Arrondissement municipal ; Édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/canton.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/canton.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Canton",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Canton ; Édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_d_arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_d_arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_d_arrondissement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu d'Arrondissement",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu d'Arrondissement ; Édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_d_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_d_arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_d_arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu d'Arrondissement municipal",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu d'Arrondissement municipal ; Édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_collectivite_territoriale.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de Collectivité territoriale",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de Collectivité territoriale ; Édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu commune",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de commune ; Édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de Commune associée ou déléguée ; Édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_departement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de Département",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de Département ; Édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_region.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/chef_lieu_de_region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de Région",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Chef-lieu de Région ; Édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/collectivite_territoriale.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Collectivité territoriale",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Collectivité territoriale ; Édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Commune",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Commune ; Édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Commune associée ou déléguée ; Édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Département",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Département ; Édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/epci.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/epci.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 EPCI",
   "description": "ADMINEXPRESS COG CARTO PE 2026 EPCI ; Édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/region.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.2026/region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE 2026 Région",
   "description": "ADMINEXPRESS COG CARTO PE 2026 Région ; Édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/arrondissement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Arrondissement",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Arrondissement",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Arrondissement municipal",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Arrondissement municipal",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/canton.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/canton.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Canton",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Canton",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_d_arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_d_arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_d_arrondissement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu d'Arrondissement",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu d'Arrondissement",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_d_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_d_arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_d_arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu d'Arrondissement municipal",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu d'Arrondissement municipal",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_collectivite_territoriale.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de Collectivité territoriale",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de Collectivité territoriale",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu commune",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de commune",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de Commune associée ou déléguée",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_departement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de Département",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de Département",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_region.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/chef_lieu_de_region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de Région",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Chef-lieu de Région",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/collectivite_territoriale.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Collectivité territoriale",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Collectivité territoriale",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Commune",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Commune",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Commune associée ou déléguée",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Département",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Département",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/epci.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/epci.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition EPCI",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition EPCI",

--- a/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/region.json
+++ b/data/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG-CARTO-PE.LATEST/region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG CARTO PE Dernière édition Région",
   "description": "ADMINEXPRESS COG CARTO PE Dernière édition Région",

--- a/data/catalog/ADMINEXPRESS-COG.2017/arrondissement_departemental.json
+++ b/data/catalog/ADMINEXPRESS-COG.2017/arrondissement_departemental.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2017/arrondissement_departemental.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2017 Arrondissement départemental",
   "description": "ADMINEXPRESS COG 2017 Arrondissement départemental ; Édition 2017-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2017/chef_lieu.json
+++ b/data/catalog/ADMINEXPRESS-COG.2017/chef_lieu.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2017/chef_lieu.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2017 Chef-lieu",
   "description": "ADMINEXPRESS COG 2017 Chef-lieu ; Édition 2017-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2017/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2017/commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2017/commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2017 Commune",
   "description": "ADMINEXPRESS COG 2017 Commune ; Édition 2017-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2017/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2017/departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2017/departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2017 Département",
   "description": "ADMINEXPRESS COG 2017 Département ; Édition 2017-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2017/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2017/epci.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2017/epci.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2017 EPCI",
   "description": "ADMINEXPRESS COG 2017 EPCI ; Édition 2017-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2017/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2017/region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2017/region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2017 Région",
   "description": "ADMINEXPRESS COG 2017 Région ; Édition 2017-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2018/arrondissement_departemental.json
+++ b/data/catalog/ADMINEXPRESS-COG.2018/arrondissement_departemental.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2018/arrondissement_departemental.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2018 Arrondissement départemental",
   "description": "ADMINEXPRESS COG 2018 Arrondissement départemental ; Édition 2018-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2018/chef_lieu.json
+++ b/data/catalog/ADMINEXPRESS-COG.2018/chef_lieu.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2018/chef_lieu.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2018 Chef-lieu",
   "description": "ADMINEXPRESS COG 2018 Chef-lieu ; Édition 2018-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2018/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2018/commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2018/commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2018 Commune",
   "description": "ADMINEXPRESS COG 2018 Commune ; Édition 2018-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2018/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2018/departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2018/departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2018 Département",
   "description": "ADMINEXPRESS COG 2018 Département ; Édition 2018-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2018/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2018/epci.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2018/epci.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2018 EPCI",
   "description": "ADMINEXPRESS COG 2018 EPCI ; Édition 2018-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2018/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2018/region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2018/region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2018 Région",
   "description": "ADMINEXPRESS COG 2018 Région ; Édition 2018-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2019/arrondissement_departemental.json
+++ b/data/catalog/ADMINEXPRESS-COG.2019/arrondissement_departemental.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2019/arrondissement_departemental.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2019 Arrondissement départemental",
   "description": "ADMINEXPRESS COG 2019 Arrondissement départemental ; Édition 2019-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2019/chef_lieu.json
+++ b/data/catalog/ADMINEXPRESS-COG.2019/chef_lieu.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2019/chef_lieu.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2019 Chef-lieu",
   "description": "ADMINEXPRESS COG 2019 Chef-lieu ; Édition 2019-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2019/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2019/commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2019/commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2019 Commune",
   "description": "ADMINEXPRESS COG 2019 Commune ; Édition 2019-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2019/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2019/departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2019/departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2019 Département",
   "description": "ADMINEXPRESS COG 2019 Département ; Édition 2019-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2019/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2019/epci.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2019/epci.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2019 EPCI",
   "description": "ADMINEXPRESS COG 2019 EPCI ; Édition 2019-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2019/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2019/region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2019/region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2019 Région",
   "description": "ADMINEXPRESS COG 2019 Région ; Édition 2019-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2020/arrondissement_departemental.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/arrondissement_departemental.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2020/arrondissement_departemental.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 Arrondissement départemental",
   "description": "ADMINEXPRESS COG 2020 Arrondissement départemental ; Édition 2020-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2020/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2020/arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2020 Arrondissement municipal ; Édition 2020-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2020/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/canton.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2020/canton.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 Canton",
   "description": "ADMINEXPRESS COG 2020 Canton ; Édition 2020-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2020/chef_lieu.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/chef_lieu.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2020/chef_lieu.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 Chef-lieu",
   "description": "ADMINEXPRESS COG 2020 Chef-lieu ; Édition 2020-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2020/chef_lieu_entite_rattachee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/chef_lieu_entite_rattachee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2020/chef_lieu_entite_rattachee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 Chef-lieu entité rattachée",
   "description": "ADMINEXPRESS COG 2020 Chef-lieu entité rattachée ; Édition 2020-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2020/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2020/commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 Commune",
   "description": "ADMINEXPRESS COG 2020 Commune ; Édition 2020-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2020/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2020/departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 Département",
   "description": "ADMINEXPRESS COG 2020 Département ; Édition 2020-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2020/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/epci.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2020/epci.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 EPCI",
   "description": "ADMINEXPRESS COG 2020 EPCI ; Édition 2020-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2020/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2020/region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2020/region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2020 Région",
   "description": "ADMINEXPRESS COG 2020 Région ; Édition 2020-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2021/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2021/arrondissement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Arrondissement",
   "description": "ADMINEXPRESS COG 2021 Arrondissement ; Édition 2021-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2021/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2021/arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2021 Arrondissement municipal ; Édition 2021-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2021/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/canton.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2021/canton.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Canton",
   "description": "ADMINEXPRESS COG 2021 Canton ; Édition 2021-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2021/chef_lieu_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/chef_lieu_arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2021/chef_lieu_arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Chef-lieu Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2021 Chef-lieu Arrondissement municipal ; Édition 2021-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2021/chef_lieu_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/chef_lieu_commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2021/chef_lieu_commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2021 Chef-lieu commune ; Édition 2021-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2021/chef_lieu_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/chef_lieu_commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2021/chef_lieu_commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Chef-lieu Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2021 Chef-lieu Commune associée ou déléguée ; Édition 2021-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2021/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2021/collectivite_territoriale.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2021 Collectivité territoriale ; Édition 2021-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2021/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2021/commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Commune",
   "description": "ADMINEXPRESS COG 2021 Commune ; Édition 2021-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2021/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2021/commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2021 Commune associée ou déléguée ; Édition 2021-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2021/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2021/departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Département",
   "description": "ADMINEXPRESS COG 2021 Département ; Édition 2021-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2021/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/epci.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2021/epci.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 EPCI",
   "description": "ADMINEXPRESS COG 2021 EPCI ; Édition 2021-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2021/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2021/region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2021/region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2021 Région",
   "description": "ADMINEXPRESS COG 2021 Région ; Édition 2021-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2022/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2022/arrondissement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Arrondissement",
   "description": "ADMINEXPRESS COG 2022 Arrondissement ; Édition 2022-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2022/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2022/arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2022 Arrondissement municipal ; Édition 2022-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2022/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/canton.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2022/canton.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Canton",
   "description": "ADMINEXPRESS COG 2022 Canton ; Édition 2022-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2022/chef_lieu_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/chef_lieu_arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2022/chef_lieu_arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Chef-lieu Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2022 Chef-lieu Arrondissement municipal ; Édition 2022-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2022/chef_lieu_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/chef_lieu_commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2022/chef_lieu_commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2022 Chef-lieu commune ; Édition 2022-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2022/chef_lieu_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/chef_lieu_commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2022/chef_lieu_commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Chef-lieu Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2022 Chef-lieu Commune associée ou déléguée ; Édition 2022-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2022/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2022/collectivite_territoriale.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2022 Collectivité territoriale ; Édition 2022-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2022/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2022/commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Commune",
   "description": "ADMINEXPRESS COG 2022 Commune ; Édition 2022-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2022/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2022/commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2022 Commune associée ou déléguée ; Édition 2022-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2022/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2022/departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Département",
   "description": "ADMINEXPRESS COG 2022 Département ; Édition 2022-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2022/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/epci.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2022/epci.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 EPCI",
   "description": "ADMINEXPRESS COG 2022 EPCI ; Édition 2022-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2022/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2022/region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2022/region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2022 Région",
   "description": "ADMINEXPRESS COG 2022 Région ; Édition 2022-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2023/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2023/arrondissement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Arrondissement",
   "description": "ADMINEXPRESS COG 2023 Arrondissement ; Édition 2023-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2023/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2023/arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2023 Arrondissement municipal ; Édition 2023-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2023/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/canton.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2023/canton.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Canton",
   "description": "ADMINEXPRESS COG 2023 Canton ; Édition 2023-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2023/chef_lieu_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/chef_lieu_arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2023/chef_lieu_arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Chef-lieu Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2023 Chef-lieu Arrondissement municipal ; Édition 2023-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2023/chef_lieu_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/chef_lieu_commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2023/chef_lieu_commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2023 Chef-lieu commune ; Édition 2023-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2023/chef_lieu_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/chef_lieu_commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2023/chef_lieu_commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Chef-lieu Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2023 Chef-lieu Commune associée ou déléguée ; Édition 2023-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2023/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2023/collectivite_territoriale.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2023 Collectivité territoriale ; Édition 2023-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2023/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2023/commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Commune",
   "description": "ADMINEXPRESS COG 2023 Commune ; Édition 2023-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2023/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2023/commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2023 Commune associée ou déléguée ; Édition 2023-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2023/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2023/departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Département",
   "description": "ADMINEXPRESS COG 2023 Département ; Édition 2023-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2023/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/epci.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2023/epci.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 EPCI",
   "description": "ADMINEXPRESS COG 2023 EPCI ; Édition 2023-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2023/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2023/region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2023/region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2023 Région",
   "description": "ADMINEXPRESS COG 2023 Région ; Édition 2023-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2024/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2024/arrondissement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Arrondissement",
   "description": "ADMINEXPRESS COG 2024 Arrondissement ; Édition 2024-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2024/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2024/arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2024 Arrondissement municipal ; Édition 2024-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2024/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/canton.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2024/canton.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Canton",
   "description": "ADMINEXPRESS COG 2024 Canton ; Édition 2024-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2024/chef_lieu_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/chef_lieu_arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2024/chef_lieu_arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Chef-lieu Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2024 Chef-lieu Arrondissement municipal ; Édition 2024-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2024/chef_lieu_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/chef_lieu_commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2024/chef_lieu_commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2024 Chef-lieu commune ; Édition 2024-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2024/chef_lieu_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/chef_lieu_commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2024/chef_lieu_commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Chef-lieu Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2024 Chef-lieu Commune associée ou déléguée ; Édition 2024-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2024/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2024/collectivite_territoriale.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2024 Collectivité territoriale ; Édition 2024-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2024/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2024/commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Commune",
   "description": "ADMINEXPRESS COG 2024 Commune ; Édition 2024-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2024/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2024/commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2024 Commune associée ou déléguée ; Édition 2024-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2024/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2024/departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Département",
   "description": "ADMINEXPRESS COG 2024 Département ; Édition 2024-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2024/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/epci.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2024/epci.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 EPCI",
   "description": "ADMINEXPRESS COG 2024 EPCI ; Édition 2024-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2024/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2024/region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2024/region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2024 Région",
   "description": "ADMINEXPRESS COG 2024 Région ; Édition 2024-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2025/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2025/arrondissement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Arrondissement",
   "description": "ADMINEXPRESS COG 2025 Arrondissement ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2025/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2025/arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2025 Arrondissement municipal ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2025/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/canton.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2025/canton.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Canton",
   "description": "ADMINEXPRESS COG 2025 Canton ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_d_arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_d_arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2025/chef_lieu_d_arrondissement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu d'Arrondissement",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu d'Arrondissement ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_d_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_d_arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2025/chef_lieu_d_arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu d'Arrondissement municipal",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu d'Arrondissement municipal ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_collectivite_territoriale.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu de Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu de Collectivité territoriale ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu de commune ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu de Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu de Commune associée ou déléguée ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu de Département",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu de Département ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2025/chef_lieu_de_region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Chef-lieu de Région",
   "description": "ADMINEXPRESS COG 2025 Chef-lieu de Région ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2025/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2025/collectivite_territoriale.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Collectivité territoriale",
   "description": "ADMINEXPRESS COG 2025 Collectivité territoriale ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2025/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2025/commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Commune",
   "description": "ADMINEXPRESS COG 2025 Commune ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2025/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2025/commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG 2025 Commune associée ou déléguée ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2025/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2025/departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Département",
   "description": "ADMINEXPRESS COG 2025 Département ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2025/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/epci.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2025/epci.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 EPCI",
   "description": "ADMINEXPRESS COG 2025 EPCI ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2025/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2025/region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2025/region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2025 Région",
   "description": "ADMINEXPRESS COG 2025 Région ; Édition 2025-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2026/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2026/arrondissement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Arrondissement ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Arrondissement",

--- a/data/catalog/ADMINEXPRESS-COG.2026/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2026/arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Arrondissement municipal ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Arrondissement municipal",

--- a/data/catalog/ADMINEXPRESS-COG.2026/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/canton.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2026/canton.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Canton ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Canton",

--- a/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_d_arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_d_arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2026/chef_lieu_d_arrondissement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu d'Arrondissement ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu d'Arrondissement",

--- a/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_d_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_d_arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2026/chef_lieu_d_arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu d'Arrondissement municipal ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu d'Arrondissement municipal",

--- a/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_collectivite_territoriale.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu de Collectivité territoriale ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu de Collectivité territoriale",

--- a/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu commune",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu de commune ; édition 2026-01-01",

--- a/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu de Commune associée ou déléguée ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu de Commune associée ou déléguée",

--- a/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu de Département ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu de Département",

--- a/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2026/chef_lieu_de_region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Chef-lieu de Région ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Chef-lieu de Région",

--- a/data/catalog/ADMINEXPRESS-COG.2026/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2026/collectivite_territoriale.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Collectivité territoriale ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Collectivité territoriale",

--- a/data/catalog/ADMINEXPRESS-COG.2026/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2026/commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Commune ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Commune",

--- a/data/catalog/ADMINEXPRESS-COG.2026/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2026/commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Commune associée ou déléguée ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Commune associée ou déléguée",

--- a/data/catalog/ADMINEXPRESS-COG.2026/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2026/departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Département ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Département",

--- a/data/catalog/ADMINEXPRESS-COG.2026/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/epci.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2026/epci.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 EPCI ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 EPCI",

--- a/data/catalog/ADMINEXPRESS-COG.2026/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.2026/region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.2026/region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG 2026 Région ; édition 2026-01-01",
   "description": "ADMINEXPRESS COG 2026 Région",

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/arrondissement.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.LATEST/arrondissement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Arrondissement",
   "description": "ADMINEXPRESS COG Dernière édition Arrondissement",

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.LATEST/arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Arrondissement municipal",
   "description": "ADMINEXPRESS COG Dernière édition Arrondissement municipal",

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/canton.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.LATEST/canton.json",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Canton",
   "description": "ADMINEXPRESS COG Dernière édition Canton",

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_d_arrondissement_municipal.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_d_arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_d_arrondissement_municipal.json",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu d Arrondissement municipal",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu d Arrondissement municipal",

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_d_epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_d_epci.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_d_epci.json",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu d EPCI",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu d EPCI",

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_canton.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_canton.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_canton.json",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu de Canton",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu de Canton",

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_collectivite_territoriale.json",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu de Collectivite Territoriale",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu de Collectivite Territoriale",

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu de commune",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu de commune",

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu de commune associée ou déléguée",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu de commune associée ou déléguée",

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_region.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.LATEST/chef_lieu_de_region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Chef-lieu de Region",
   "description": "ADMINEXPRESS COG Dernière édition Chef-lieu de Region",

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/collectivite_territoriale.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.LATEST/collectivite_territoriale.json",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Collectivité territoriale",
   "description": "ADMINEXPRESS COG Dernière édition Collectivité territoriale",

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/commune.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.LATEST/commune.json",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Commune",
   "description": "ADMINEXPRESS COG Dernière édition Commune",

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/commune_associee_ou_deleguee.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.LATEST/commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Commune associée ou déléguée",
   "description": "ADMINEXPRESS COG Dernière édition Commune associée ou déléguée",

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/departement.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.LATEST/departement.json",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Département",
   "description": "ADMINEXPRESS COG Dernière édition Département",

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/epci.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/epci.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.LATEST/epci.json",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition EPCI",
   "description": "ADMINEXPRESS COG Dernière édition EPCI",

--- a/data/catalog/ADMINEXPRESS-COG.LATEST/region.json
+++ b/data/catalog/ADMINEXPRESS-COG.LATEST/region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/ADMINEXPRESS-COG.LATEST/region.json",
   "type": "object",
   "title": "ADMINEXPRESS COG Dernière édition Région",
   "description": "ADMINEXPRESS COG Dernière édition Région",

--- a/data/catalog/BDTOPO_V3/aerodrome.json
+++ b/data/catalog/BDTOPO_V3/aerodrome.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/aerodrome.json",
   "type": "object",
   "title": "Aérodrome",
   "x-ign-theme": "Transport",

--- a/data/catalog/BDTOPO_V3/arrondissement.json
+++ b/data/catalog/BDTOPO_V3/arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/arrondissement.json",
   "type": "object",
   "title": "Arrondissement",
   "x-ign-theme": "Administratif",

--- a/data/catalog/BDTOPO_V3/arrondissement_municipal.json
+++ b/data/catalog/BDTOPO_V3/arrondissement_municipal.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/arrondissement_municipal.json",
   "type": "object",
   "title": "Arrondissement municipal",
   "x-ign-theme": "Administratif",

--- a/data/catalog/BDTOPO_V3/bassin_versant_topographique.json
+++ b/data/catalog/BDTOPO_V3/bassin_versant_topographique.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/bassin_versant_topographique.json",
   "type": "object",
   "title": "Bassin versant topographique",
   "x-ign-theme": "Hydrographie",

--- a/data/catalog/BDTOPO_V3/batiment.json
+++ b/data/catalog/BDTOPO_V3/batiment.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/batiment.json",
   "type": "object",
   "title": "Bâtiment",
   "x-ign-theme": "Bâti",

--- a/data/catalog/BDTOPO_V3/canalisation.json
+++ b/data/catalog/BDTOPO_V3/canalisation.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/canalisation.json",
   "type": "object",
   "title": "Canalisation",
   "x-ign-theme": "Services et activités",

--- a/data/catalog/BDTOPO_V3/cimetiere.json
+++ b/data/catalog/BDTOPO_V3/cimetiere.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/cimetiere.json",
   "type": "object",
   "title": "Cimetière",
   "x-ign-theme": "Bâti",

--- a/data/catalog/BDTOPO_V3/collectivite_territoriale.json
+++ b/data/catalog/BDTOPO_V3/collectivite_territoriale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/collectivite_territoriale.json",
   "type": "object",
   "title": "Collectivité territoriale",
   "x-ign-theme": "Administratif",

--- a/data/catalog/BDTOPO_V3/commune.json
+++ b/data/catalog/BDTOPO_V3/commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/commune.json",
   "type": "object",
   "title": "Commune",
   "x-ign-theme": "Administratif",

--- a/data/catalog/BDTOPO_V3/commune_associee_ou_deleguee.json
+++ b/data/catalog/BDTOPO_V3/commune_associee_ou_deleguee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/commune_associee_ou_deleguee.json",
   "type": "object",
   "title": "Commune associée ou déléguée",
   "x-ign-theme": "Administratif",

--- a/data/catalog/BDTOPO_V3/condominium.json
+++ b/data/catalog/BDTOPO_V3/condominium.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/condominium.json",
   "type": "object",
   "title": "Condominium",
   "x-ign-theme": "Administratif",

--- a/data/catalog/BDTOPO_V3/construction_lineaire.json
+++ b/data/catalog/BDTOPO_V3/construction_lineaire.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/construction_lineaire.json",
   "type": "object",
   "title": "Construction linéaire",
   "x-ign-theme": "Bâti",

--- a/data/catalog/BDTOPO_V3/construction_ponctuelle.json
+++ b/data/catalog/BDTOPO_V3/construction_ponctuelle.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/construction_ponctuelle.json",
   "type": "object",
   "title": "Construction ponctuelle",
   "x-ign-theme": "Bâti",

--- a/data/catalog/BDTOPO_V3/construction_surfacique.json
+++ b/data/catalog/BDTOPO_V3/construction_surfacique.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/construction_surfacique.json",
   "type": "object",
   "title": "Construction surfacique",
   "x-ign-theme": "Bâti",

--- a/data/catalog/BDTOPO_V3/cours_d_eau.json
+++ b/data/catalog/BDTOPO_V3/cours_d_eau.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/cours_d_eau.json",
   "type": "object",
   "title": "Cours d'eau",
   "x-ign-theme": "Hydrographie",

--- a/data/catalog/BDTOPO_V3/departement.json
+++ b/data/catalog/BDTOPO_V3/departement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/departement.json",
   "type": "object",
   "title": "Département",
   "x-ign-theme": "Administratif",

--- a/data/catalog/BDTOPO_V3/detail_hydrographique.json
+++ b/data/catalog/BDTOPO_V3/detail_hydrographique.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/detail_hydrographique.json",
   "type": "object",
   "title": "Détail hydrographique",
   "x-ign-theme": "Hydrographie",

--- a/data/catalog/BDTOPO_V3/detail_orographique.json
+++ b/data/catalog/BDTOPO_V3/detail_orographique.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/detail_orographique.json",
   "type": "object",
   "title": "Détail orographique",
   "x-ign-theme": "Lieux nommés",

--- a/data/catalog/BDTOPO_V3/epci.json
+++ b/data/catalog/BDTOPO_V3/epci.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/epci.json",
   "type": "object",
   "title": "EPCI",
   "x-ign-theme": "Administratif",

--- a/data/catalog/BDTOPO_V3/equipement_de_transport.json
+++ b/data/catalog/BDTOPO_V3/equipement_de_transport.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/equipement_de_transport.json",
   "type": "object",
   "title": "Equipement de transport",
   "x-ign-theme": "Transport",

--- a/data/catalog/BDTOPO_V3/foret_publique.json
+++ b/data/catalog/BDTOPO_V3/foret_publique.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/foret_publique.json",
   "type": "object",
   "title": "Forêt publique",
   "x-ign-theme": "Zones réglementées",

--- a/data/catalog/BDTOPO_V3/haie.json
+++ b/data/catalog/BDTOPO_V3/haie.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/haie.json",
   "type": "object",
   "title": "Haie",
   "x-ign-theme": "Occupation du sol",

--- a/data/catalog/BDTOPO_V3/itineraire_autre.json
+++ b/data/catalog/BDTOPO_V3/itineraire_autre.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/itineraire_autre.json",
   "type": "object",
   "title": "Itinéraire autre",
   "x-ign-theme": "Transport",

--- a/data/catalog/BDTOPO_V3/lieu_dit_non_habite.json
+++ b/data/catalog/BDTOPO_V3/lieu_dit_non_habite.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/lieu_dit_non_habite.json",
   "type": "object",
   "title": "Lieu-dit non habité",
   "x-ign-theme": "Lieux nommés",

--- a/data/catalog/BDTOPO_V3/ligne_electrique.json
+++ b/data/catalog/BDTOPO_V3/ligne_electrique.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/ligne_electrique.json",
   "type": "object",
   "title": "Ligne électrique",
   "x-ign-theme": "Services et activités",

--- a/data/catalog/BDTOPO_V3/ligne_orographique.json
+++ b/data/catalog/BDTOPO_V3/ligne_orographique.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/ligne_orographique.json",
   "type": "object",
   "title": "Ligne orographique",
   "x-ign-theme": "Bâti",

--- a/data/catalog/BDTOPO_V3/limite_terre_mer.json
+++ b/data/catalog/BDTOPO_V3/limite_terre_mer.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/limite_terre_mer.json",
   "type": "object",
   "title": "Limite terre-mer",
   "x-ign-theme": "Hydrographie",

--- a/data/catalog/BDTOPO_V3/noeud_hydrographique.json
+++ b/data/catalog/BDTOPO_V3/noeud_hydrographique.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/noeud_hydrographique.json",
   "type": "object",
   "title": "Noeud hydrographique",
   "x-ign-theme": "Hydrographie",

--- a/data/catalog/BDTOPO_V3/non_communication.json
+++ b/data/catalog/BDTOPO_V3/non_communication.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/non_communication.json",
   "type": "object",
   "title": "Non-communication",
   "x-ign-theme": "Transport",

--- a/data/catalog/BDTOPO_V3/parc_ou_reserve.json
+++ b/data/catalog/BDTOPO_V3/parc_ou_reserve.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/parc_ou_reserve.json",
   "type": "object",
   "title": "Parc ou réserve",
   "x-ign-theme": "Zones réglementées",

--- a/data/catalog/BDTOPO_V3/piste_d_aerodrome.json
+++ b/data/catalog/BDTOPO_V3/piste_d_aerodrome.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/piste_d_aerodrome.json",
   "type": "object",
   "title": "Piste d'aérodrome",
   "x-ign-theme": "Transport",

--- a/data/catalog/BDTOPO_V3/plan_d_eau.json
+++ b/data/catalog/BDTOPO_V3/plan_d_eau.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/plan_d_eau.json",
   "type": "object",
   "title": "Plan d'eau",
   "x-ign-theme": "Hydrographie",

--- a/data/catalog/BDTOPO_V3/point_d_acces.json
+++ b/data/catalog/BDTOPO_V3/point_d_acces.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/point_d_acces.json",
   "type": "object",
   "title": "Point d'accès",
   "x-ign-theme": "Transport",

--- a/data/catalog/BDTOPO_V3/point_de_repere.json
+++ b/data/catalog/BDTOPO_V3/point_de_repere.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/point_de_repere.json",
   "type": "object",
   "title": "Point de repère",
   "x-ign-theme": "Transport",

--- a/data/catalog/BDTOPO_V3/point_du_reseau.json
+++ b/data/catalog/BDTOPO_V3/point_du_reseau.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/point_du_reseau.json",
   "type": "object",
   "title": "Point du réseau",
   "x-ign-theme": "Transport",

--- a/data/catalog/BDTOPO_V3/poste_de_transformation.json
+++ b/data/catalog/BDTOPO_V3/poste_de_transformation.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/poste_de_transformation.json",
   "type": "object",
   "title": "Poste de transformation",
   "x-ign-theme": "Services et activités",

--- a/data/catalog/BDTOPO_V3/pylone.json
+++ b/data/catalog/BDTOPO_V3/pylone.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/pylone.json",
   "type": "object",
   "title": "Pylône",
   "x-ign-theme": "Bâti",

--- a/data/catalog/BDTOPO_V3/region.json
+++ b/data/catalog/BDTOPO_V3/region.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/region.json",
   "type": "object",
   "title": "Région",
   "x-ign-theme": "Administratif",

--- a/data/catalog/BDTOPO_V3/reservoir.json
+++ b/data/catalog/BDTOPO_V3/reservoir.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/reservoir.json",
   "type": "object",
   "title": "Réservoir",
   "x-ign-theme": "Bâti",

--- a/data/catalog/BDTOPO_V3/route_numerotee_ou_nommee.json
+++ b/data/catalog/BDTOPO_V3/route_numerotee_ou_nommee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/route_numerotee_ou_nommee.json",
   "type": "object",
   "title": "Route numérotée ou nommée",
   "x-ign-theme": "Transport",

--- a/data/catalog/BDTOPO_V3/section_de_points_de_repere.json
+++ b/data/catalog/BDTOPO_V3/section_de_points_de_repere.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/section_de_points_de_repere.json",
   "type": "object",
   "title": "Section de points de repère",
   "x-ign-theme": "Transport",

--- a/data/catalog/BDTOPO_V3/surface_hydrographique.json
+++ b/data/catalog/BDTOPO_V3/surface_hydrographique.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/surface_hydrographique.json",
   "type": "object",
   "title": "Surface hydrographique",
   "x-ign-theme": "Hydrographie",

--- a/data/catalog/BDTOPO_V3/terrain_de_sport.json
+++ b/data/catalog/BDTOPO_V3/terrain_de_sport.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/terrain_de_sport.json",
   "type": "object",
   "title": "Terrain de sport",
   "x-ign-theme": "Bâti",

--- a/data/catalog/BDTOPO_V3/toponymie.json
+++ b/data/catalog/BDTOPO_V3/toponymie.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/toponymie.json",
   "type": "object",
   "title": "Toponymie",
   "x-ign-theme": "Lieux nommés",

--- a/data/catalog/BDTOPO_V3/transport_par_cable.json
+++ b/data/catalog/BDTOPO_V3/transport_par_cable.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/transport_par_cable.json",
   "type": "object",
   "title": "Transport par câble",
   "x-ign-theme": "Transport",

--- a/data/catalog/BDTOPO_V3/troncon_de_route.json
+++ b/data/catalog/BDTOPO_V3/troncon_de_route.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/troncon_de_route.json",
   "type": "object",
   "title": "Tronçon de route",
   "x-ign-theme": "Transport",

--- a/data/catalog/BDTOPO_V3/troncon_de_voie_ferree.json
+++ b/data/catalog/BDTOPO_V3/troncon_de_voie_ferree.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/troncon_de_voie_ferree.json",
   "type": "object",
   "title": "Tronçon de voie ferrée",
   "x-ign-theme": "Transport",

--- a/data/catalog/BDTOPO_V3/troncon_hydrographique.json
+++ b/data/catalog/BDTOPO_V3/troncon_hydrographique.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/troncon_hydrographique.json",
   "type": "object",
   "title": "Tronçon hydrographique",
   "x-ign-theme": "Hydrographie",

--- a/data/catalog/BDTOPO_V3/voie_ferree_nommee.json
+++ b/data/catalog/BDTOPO_V3/voie_ferree_nommee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/voie_ferree_nommee.json",
   "type": "object",
   "title": "Voie ferrée nommée",
   "x-ign-theme": "Transport",

--- a/data/catalog/BDTOPO_V3/voie_nommee.json
+++ b/data/catalog/BDTOPO_V3/voie_nommee.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/voie_nommee.json",
   "type": "object",
   "title": "Voie nommée",
   "x-ign-theme": "Adresses",

--- a/data/catalog/BDTOPO_V3/zone_d_activite_ou_d_interet.json
+++ b/data/catalog/BDTOPO_V3/zone_d_activite_ou_d_interet.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/zone_d_activite_ou_d_interet.json",
   "type": "object",
   "title": "Zone d'activité ou d'intérêt",
   "x-ign-theme": "Services et activités",

--- a/data/catalog/BDTOPO_V3/zone_d_estran.json
+++ b/data/catalog/BDTOPO_V3/zone_d_estran.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/zone_d_estran.json",
   "type": "object",
   "title": "Zone d'estran",
   "x-ign-theme": "Occupation du sol",

--- a/data/catalog/BDTOPO_V3/zone_d_habitation.json
+++ b/data/catalog/BDTOPO_V3/zone_d_habitation.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/zone_d_habitation.json",
   "type": "object",
   "title": "Zone d'habitation",
   "x-ign-theme": "Lieux nommés",

--- a/data/catalog/BDTOPO_V3/zone_de_vegetation.json
+++ b/data/catalog/BDTOPO_V3/zone_de_vegetation.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/BDTOPO_V3/zone_de_vegetation.json",
   "type": "object",
   "title": "Zone de végétation",
   "x-ign-theme": "Occupation du sol",

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/arrondissement.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/arrondissement.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/arrondissement.json",
   "type": "object",
   "title": "PCI Vecteur : Arrondissements",
   "description": "Arrondissements ; Édition 2026-03-01",

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/batiment.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/batiment.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/batiment.json",
   "type": "object",
   "title": "PCI Vecteur : Bâtiments",
   "description": "Bâtiments ; Édition 2026-03-01",

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/borne_limite_propriete.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/borne_limite_propriete.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/borne_limite_propriete.json",
   "type": "object",
   "title": "PCI Vecteur : Bornes de limite de propriété",
   "description": "Bornes de limite de propriété ; Édition 2026-03-01",

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/borne_parcelle.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/borne_parcelle.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/borne_parcelle.json",
   "type": "object",
   "title": "PCI Vecteur : Lien bornes parcelles",
   "description": "Lien bornes parcelles ; Édition 2026-03-01",

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/commune.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/commune.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/commune.json",
   "type": "object",
   "title": "PCI Vecteur : Communes",
   "description": "Communes ; Édition 2026-03-01",

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/feuille.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/feuille.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/feuille.json",
   "type": "object",
   "title": "PCI Vecteur : Feuilles",
   "description": "Feuilles ; Édition 2026-03-01",

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/localisant.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/localisant.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/localisant.json",
   "type": "object",
   "title": "PCI Vecteur : Localisants",
   "description": "Localisants ; Édition 2026-03-01",

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/parcelle.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/parcelle.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/parcelle.json",
   "type": "object",
   "title": "PCI Vecteur : Parcelles",
   "description": "Parcelles ; Édition 2026-03-01",

--- a/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/subdivision_fiscale.json
+++ b/data/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/subdivision_fiscale.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/CADASTRALPARCELS.PARCELLAIRE_EXPRESS/subdivision_fiscale.json",
   "type": "object",
   "title": "PCI Vecteur : Subdivisions fiscales",
   "description": "Subdivisions fiscales ; Édition 2026-03-01",

--- a/data/catalog/INSEE.FILOSOFI.INDICATORS/carreaux_1km.json
+++ b/data/catalog/INSEE.FILOSOFI.INDICATORS/carreaux_1km.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/INSEE.FILOSOFI.INDICATORS/carreaux_1km.json",
   "type": "object",
   "title": "Carroyages INSEE",
   "description": "Carroyages INSEE à 200 m, à 1 km et à la plus grande échelle diffusable ",

--- a/data/catalog/INSEE.FILOSOFI.INDICATORS/carreaux_200m.json
+++ b/data/catalog/INSEE.FILOSOFI.INDICATORS/carreaux_200m.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/INSEE.FILOSOFI.INDICATORS/carreaux_200m.json",
   "type": "object",
   "title": "Carroyages INSEE",
   "description": "Carroyages INSEE à 200 m, à 1 km et à la plus grande échelle diffusable ",

--- a/data/catalog/STATISTICALUNITS.IRIS.PE/contours_iris_pe.json
+++ b/data/catalog/STATISTICALUNITS.IRIS.PE/contours_iris_pe.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/STATISTICALUNITS.IRIS.PE/contours_iris_pe.json",
   "type": "object",
   "title": "Contours géométriques des IRIS de l'INSEE à petite échelle",
   "description": "Contours géométriques des IRIS de l'INSEE à petite échelle sur toute la France ; Edition : 2026-01-01",

--- a/data/catalog/STATISTICALUNITS.IRIS/contours_iris.json
+++ b/data/catalog/STATISTICALUNITS.IRIS/contours_iris.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/STATISTICALUNITS.IRIS/contours_iris.json",
   "type": "object",
   "title": "Contours géométriques des IRIS de l INSEE à moyenne échelle",
   "description": "Contours géométriques des IRIS de l INSEE à moyenne échelle sur toute la France ; Edition 2026-01-01",

--- a/data/catalog/STATISTICALUNITS.IRISGE/iris_ge.json
+++ b/data/catalog/STATISTICALUNITS.IRISGE/iris_ge.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/STATISTICALUNITS.IRISGE/iris_ge.json",
   "type": "object",
   "title": "Contours géométriques des IRIS de l'INSEE à grande échelle",
   "description": "Contours géométriques des IRIS de l'INSEE à grande échelle sur toute la France ; Edition : 2026-01-01",

--- a/data/catalog/wfs_du/doc_urba.json
+++ b/data/catalog/wfs_du/doc_urba.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/doc_urba.json",
   "type": "object",
   "title": "Document d'urbanisme",
   "description": "Classe sémantique décrivant le document d'urbanisme, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_du/doc_urba_com.json
+++ b/data/catalog/wfs_du/doc_urba_com.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/doc_urba_com.json",
   "type": "object",
   "title": "Document d'urbanisme",
   "description": "Classe sémantique décrivant le document d'urbanisme, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_du/document.json
+++ b/data/catalog/wfs_du/document.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/document.json",
   "type": "object",
   "title": "Document d'urbanisme",
   "description": "Emprise du document d'urbanisme, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_du/habillage_lin.json
+++ b/data/catalog/wfs_du/habillage_lin.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/habillage_lin.json",
   "type": "object",
   "title": "Habillages linéaires",
   "description": "Objet linéaire indicatif porté sur le document d'urbanisme pour l'habillage du plan, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_du/habillage_pct.json
+++ b/data/catalog/wfs_du/habillage_pct.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/habillage_pct.json",
   "type": "object",
   "title": "Habillages ponctuels",
   "description": "Objet ponctuel indicatif porté sur le document d'urbanisme pour l'habillage du plan, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_du/habillage_surf.json
+++ b/data/catalog/wfs_du/habillage_surf.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/habillage_surf.json",
   "type": "object",
   "title": "Habillages surfaciques",
   "description": "Objet surfacique indicatif porté sur le document d'urbanisme pour l'habillage du plan, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_du/habillage_txt.json
+++ b/data/catalog/wfs_du/habillage_txt.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/habillage_txt.json",
   "type": "object",
   "title": "Etiquette ponctuelle de l’habillage du plan",
   "description": "Étiquette ponctuelle portée sur le document d'urbanisme pour l’habillage du plan, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_du/info_lin.json
+++ b/data/catalog/wfs_du/info_lin.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/info_lin.json",
   "type": "object",
   "title": "Informations linéaires",
   "description": "Périmètre linéaire à reporter à titre d’information, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_du/info_pct.json
+++ b/data/catalog/wfs_du/info_pct.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/info_pct.json",
   "type": "object",
   "title": "Informations ponctuelles",
   "description": "Périmètre ponctuel à reporter à titre d’information, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_du/info_surf.json
+++ b/data/catalog/wfs_du/info_surf.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/info_surf.json",
   "type": "object",
   "title": "Informations surfaciques",
   "description": "Périmètre surfacique à reporter à titre d’information, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_du/mec.json
+++ b/data/catalog/wfs_du/mec.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/mec.json",
   "type": "object",
   "title": "Mise en compatibilité",
   "description": "Mise en compatibilité",

--- a/data/catalog/wfs_du/municipality.json
+++ b/data/catalog/wfs_du/municipality.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/municipality.json",
   "type": "object",
   "title": "Communes",
   "description": "Emprise communale, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_du/prescription_lin.json
+++ b/data/catalog/wfs_du/prescription_lin.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/prescription_lin.json",
   "type": "object",
   "title": "Prescriptions linéaires",
   "description": "Prescriptions linéaires se superposant au zonage, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_du/prescription_pct.json
+++ b/data/catalog/wfs_du/prescription_pct.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/prescription_pct.json",
   "type": "object",
   "title": "Prescriptions ponctuelles",
   "description": "Prescriptions ponctuelles se superposant au zonage, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_du/prescription_surf.json
+++ b/data/catalog/wfs_du/prescription_surf.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/prescription_surf.json",
   "type": "object",
   "title": "Prescriptions surfaciques",
   "description": "Prescriptions surfaciques se superposant au zonage, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_du/secteur_cc.json
+++ b/data/catalog/wfs_du/secteur_cc.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/secteur_cc.json",
   "type": "object",
   "title": "Secteurs de la carte communale",
   "description": "Secteurs de carte communale, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_du/zone_urba.json
+++ b/data/catalog/wfs_du/zone_urba.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_du/zone_urba.json",
   "type": "object",
   "title": "Zonage du document d'urbanisme",
   "description": "Zonage du document d'urbanisme, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_scot/doc_urba.json
+++ b/data/catalog/wfs_scot/doc_urba.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_scot/doc_urba.json",
   "type": "object",
   "title": "Document d'urbanisme",
   "description": "Classe sémantique décrivant le Schéma de Cohérence Territorial, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_scot/doc_urba_com.json
+++ b/data/catalog/wfs_scot/doc_urba_com.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_scot/doc_urba_com.json",
   "type": "object",
   "title": "Document d'urbanisme",
   "description": "Relations entre le Schéma de Cohérence Territorial et les communes auxquelles il s'applique, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_scot/perimetre_scot.json
+++ b/data/catalog/wfs_scot/perimetre_scot.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_scot/perimetre_scot.json",
   "type": "object",
   "title": "Perimetre du Schéma de cohérence territorial",
   "description": "Périmètre publié du Schéma de Cohérence Territorial, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_scot/scot.json
+++ b/data/catalog/wfs_scot/scot.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_scot/scot.json",
   "type": "object",
   "title": "Schéma de cohérence territorial",
   "description": "Etat du Schéma de Cohérence Territorial, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_sup/acte_sup.json
+++ b/data/catalog/wfs_sup/acte_sup.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_sup/acte_sup.json",
   "type": "object",
   "title": "Acte de servitude d'utilité publique",
   "description": "Liste des actes instituant une servitude d'utilité publique, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_sup/assiette_sup_l.json
+++ b/data/catalog/wfs_sup/assiette_sup_l.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_sup/assiette_sup_l.json",
   "type": "object",
   "title": "Assiette de servitude d'utilité publique",
   "description": "Assiettes linéaires liées aux servitudes, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_sup/assiette_sup_p.json
+++ b/data/catalog/wfs_sup/assiette_sup_p.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_sup/assiette_sup_p.json",
   "type": "object",
   "title": "Assiette de servitude d'utilité publique",
   "description": "Assiettes ponctuelles liées aux servitudes, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_sup/assiette_sup_s.json
+++ b/data/catalog/wfs_sup/assiette_sup_s.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_sup/assiette_sup_s.json",
   "type": "object",
   "title": "Assiette de servitude d'utilité publique",
   "description": "Assiettes surfaciques liées aux servitudes, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_sup/generateur_sup_l.json
+++ b/data/catalog/wfs_sup/generateur_sup_l.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_sup/generateur_sup_l.json",
   "type": "object",
   "title": "Générateur de servitude d'utilité publique",
   "description": "Générateurs linéaires liés aux servitudes, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_sup/generateur_sup_p.json
+++ b/data/catalog/wfs_sup/generateur_sup_p.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_sup/generateur_sup_p.json",
   "type": "object",
   "title": "Générateur de servitude d'utilité publique",
   "description": "Générateurs ponctuels liés aux servitudes, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_sup/generateur_sup_s.json
+++ b/data/catalog/wfs_sup/generateur_sup_s.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_sup/generateur_sup_s.json",
   "type": "object",
   "title": "Générateur de servitude d'utilité publique",
   "description": "Générateurs surfaciques liés aux servitudes, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_sup/gestionnaire_sup.json
+++ b/data/catalog/wfs_sup/gestionnaire_sup.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_sup/gestionnaire_sup.json",
   "type": "object",
   "title": "Organisme gestionnaire ou organisme ressource de la servitude",
   "description": "Gestionnaires de servitude d'utilité publique, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_sup/servitude.json
+++ b/data/catalog/wfs_sup/servitude.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_sup/servitude.json",
   "type": "object",
   "title": "Servitude d'utilité publique",
   "description": "Liste des servitudes d'utilité publique, données issues du Géoportail de l'urbanisme",

--- a/data/catalog/wfs_sup/servitude_acte_sup.json
+++ b/data/catalog/wfs_sup/servitude_acte_sup.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://ignfab.github.io/gpf-schema-store/catalog/wfs_sup/servitude_acte_sup.json",
   "type": "object",
   "title": "Relation entre ACTE_SUP et SERVITUDE",
   "description": "Relation entre les SUP et les actes les instituant, données issues du Géoportail de l'urbanisme",

--- a/src/ogc-api-feature/types.ts
+++ b/src/ogc-api-feature/types.ts
@@ -63,6 +63,7 @@ export type OgcCollectionProperty = z.infer<typeof zOgcCollectionProperty>;
  */
 export const zOgcCollectionSchema = z.object({
   $schema: z.literal('https://json-schema.org/draft/2020-12/schema'),
+  $id: z.string().url(),
   type: z.literal('object'),
   title: z.string(),
   'x-ign-theme': z.string().optional(),

--- a/src/ogc-api-feature/writer.ts
+++ b/src/ogc-api-feature/writer.ts
@@ -22,6 +22,11 @@ import type {
  */
 
 const JSON_SCHEMA_DRAFT = 'https://json-schema.org/draft/2020-12/schema' as const;
+const CATALOG_SCHEMA_ID_BASE_URL = 'https://ignfab.github.io/gpf-schema-store/catalog' as const;
+
+function buildCollectionSchemaId(collection: EnrichedCollection): string {
+  return `${CATALOG_SCHEMA_ID_BASE_URL}/${collection.namespace}/${collection.name}.json`;
+}
 
 /*
  * =============================================================================
@@ -143,6 +148,7 @@ export function renderCollectionSchema(collection: EnrichedCollection): OgcColle
 
   const schema: Partial<OgcCollectionSchema> = {
     $schema: JSON_SCHEMA_DRAFT,
+    $id: buildCollectionSchemaId(collection),
     type: 'object',
     title: collection.title,
   };

--- a/test/unit/cli/render-catalog.test.ts
+++ b/test/unit/cli/render-catalog.test.ts
@@ -42,6 +42,10 @@ describe('writeRenderedCatalog', () => {
       expect.stringMatching(/[\\/]tmp[\\/]catalog[\\/]NS[\\/]feature\.json$/),
       expect.stringContaining('"$schema": "https://json-schema.org/draft/2020-12/schema"'),
     );
+    expect(fsMocks.writeFileSync).toHaveBeenCalledWith(
+      expect.stringMatching(/[\\/]tmp[\\/]catalog[\\/]NS[\\/]feature\.json$/),
+      expect.stringContaining('"$id": "https://ignfab.github.io/gpf-schema-store/catalog/NS/feature.json"'),
+    );
   });
 
   it('cleans the output directory when requested', async () => {

--- a/test/unit/ogc-api-feature/writer.test.ts
+++ b/test/unit/ogc-api-feature/writer.test.ts
@@ -56,6 +56,7 @@ describe('renderCollectionSchema', () => {
 
     expect(Object.keys(schema)).toEqual([
       '$schema',
+      '$id',
       'type',
       'title',
       'x-ign-theme',
@@ -74,6 +75,7 @@ describe('renderCollectionSchema', () => {
 
     expect(schema).toEqual({
       $schema: 'https://json-schema.org/draft/2020-12/schema',
+      $id: 'https://ignfab.github.io/gpf-schema-store/catalog/NS/feature.json',
       type: 'object',
       title: 'Feature',
       'x-ign-theme': 'Theme',
@@ -129,6 +131,7 @@ describe('renderCollectionSchema', () => {
 
     expect(Object.keys(schema)).toEqual([
       '$schema',
+      '$id',
       'type',
       'title',
       'x-ign-theme',


### PR DESCRIPTION
Implement https://github.com/ignfab/geocontext/issues/186#issuecomment-5189173469.

This ensures conformity with OGC API Features ("$id" is mandatory) and it will enable futher improvements on geocontext.

@mborne to make this work, you must go to Settings → Pages → Build and deployment, and then set Source to GitHub Actions (I'm not admin of the repo).